### PR TITLE
Feature Proposal: Axis Label Formatting

### DIFF
--- a/doc/docs.json
+++ b/doc/docs.json
@@ -39,7 +39,8 @@
               "features/animations",
               "features/theming",
               "features/interactions",
-              "features/export"
+              "features/export",
+              "features/axis-formatting"
             ]
           },
           {

--- a/doc/features/axis-formatting.mdx
+++ b/doc/features/axis-formatting.mdx
@@ -1,0 +1,211 @@
+---
+title: "Axis Formatting"
+description: "Format axis labels with prefix, suffix, and decimal places for professional charts"
+---
+
+## Overview
+
+Cristalyse's axis formatting system provides precise control over how axis labels are displayed. Add currency symbols, percentage signs, custom prefixes, and control decimal places to create professional, readable charts.
+
+## Basic Usage
+
+### Currency Formatting
+
+Add dollar signs or other currency symbols to your Y-axis:
+
+```dart
+CristalyseChart()
+  .data(revenueData)
+  .mapping(x: 'month', y: 'revenue')
+  .geomBar()
+  .formatYAxis(prefix: '\$', decimals: 0)  // $1234
+  .build()
+```
+
+### Percentage Formatting
+
+Perfect for conversion rates and growth metrics:
+
+```dart
+CristalyseChart()
+  .data(conversionData)
+  .mapping(x: 'month', y: 'rate')
+  .geomLine()
+  .formatYAxis(suffix: '%', decimals: 1)  // 15.2%
+  .build()
+```
+
+### Custom Decimal Places
+
+Control precision for different data types:
+
+```dart
+CristalyseChart()
+  .data(precisionData)
+  .mapping(x: 'category', y: 'value')
+  .geomBar()
+  .formatYAxis(decimals: 3)  // 3.142
+  .build()
+```
+
+## Predefined Formatters
+
+Use built-in formatters for common cases:
+
+```dart
+// Currency with $ prefix
+.formatYAxis(formatter: AxisFormatter.currency)
+
+// Percentage with % suffix  
+.formatYAxis(formatter: AxisFormatter.percentage)
+
+// Custom currency symbol
+.formatYAxis(formatter: AxisFormatter.currencyWithSymbol('€'))
+```
+
+## Dual-Axis Formatting
+
+Format each axis independently in dual-axis charts:
+
+```dart
+CristalyseChart()
+  .data(businessData)
+  .mapping(x: 'month', y: 'revenue')
+  .mappingY2('conversion_rate')
+  .geomBar()                                    // Revenue bars
+  .geomLine(yAxis: YAxis.secondary)            // Conversion line
+  .formatYAxis(prefix: '\$', decimals: 0)       // Left: $1234
+  .formatY2Axis(suffix: '%', decimals: 1)      // Right: 15.2%
+  .build()
+```
+
+## Custom Formatters
+
+Create your own formatters for specialized needs:
+
+```dart
+// Custom three-letter currency code
+final jpyFormatter = AxisFormatter.custom(
+  prefix: 'JPY ',
+  suffix: '',
+  decimals: 0,
+);
+
+CristalyseChart()
+  .data(data)
+  .mapping(x: 'month', y: 'revenue_jpy')
+  .geomBar()
+  .formatYAxis(formatter: jpyFormatter)  // JPY 1500
+  .build()
+```
+
+## Advanced Examples
+
+### Regional Growth Rates Dashboard
+
+```dart
+CristalyseChart()
+  .data(internationalData)
+  .mapping(x: 'region', y: 'revenue_usd')
+  .mappingY2('growth_rate')
+  .geomBar(color: Colors.blue)
+  .geomLine(
+    yAxis: YAxis.secondary,
+    color: Colors.red,
+    strokeWidth: 3.0,
+  )
+  .formatXAxis()  // No formatting for region names
+  .formatYAxis(prefix: '\$', suffix: 'M', decimals: 1)  // $2.5M
+  .formatY2Axis(suffix: '%', decimals: 0)               // 23%
+  .build()
+```
+
+### Financial Performance Metrics
+
+```dart
+CristalyseChart()
+  .data(financialMetrics)
+  .mapping(x: 'quarter', y: 'profit_margin')
+  .geomArea(alpha: 0.3)
+  .geomLine(strokeWidth: 2.0)
+  .formatYAxis(
+    prefix: '',
+    suffix: '%',
+    decimals: 2,  // 18.75%
+  )
+  .build()
+```
+
+## API Reference
+
+### Format Methods
+
+```dart
+// Format X-axis labels
+.formatXAxis({String? prefix, String? suffix, int? decimals, AxisFormatter? formatter})
+
+// Format Y-axis labels (primary/left)
+.formatYAxis({String? prefix, String? suffix, int? decimals, AxisFormatter? formatter})
+
+// Format secondary Y-axis labels (right)
+.formatY2Axis({String? prefix, String? suffix, int? decimals, AxisFormatter? formatter})
+```
+
+### AxisFormatter Class
+
+```dart
+// Constructor
+AxisFormatter({String prefix = '', String suffix = '', int? decimals})
+
+// Predefined formatters
+AxisFormatter.currency         // $ prefix
+AxisFormatter.percentage       // % suffix
+
+// Factory methods
+AxisFormatter.currencyWithSymbol(String symbol)
+AxisFormatter.custom({String prefix, String suffix, int? decimals})
+```
+
+## Best Practices
+
+### 1. Consistent Formatting
+Use the same formatter throughout related charts:
+
+```dart
+final currencyFormatter = AxisFormatter.currency;
+
+// Apply to multiple charts
+chart1.formatYAxis(formatter: currencyFormatter);
+chart2.formatYAxis(formatter: currencyFormatter);
+```
+
+### 2. Appropriate Decimal Places
+- **Currency**: 0-2 decimals (`$1,234` or `$1,234.50`)
+- **Percentages**: 0-1 decimals (`15%` or `15.2%`)
+- **Precise metrics**: 2-3 decimals (`3.142`)
+
+### 3. Clear Axis Labels
+Combine formatting with clear data:
+
+```dart
+// Revenue in thousands
+.formatYAxis(prefix: '\$', suffix: 'K', decimals: 0)  // $125K
+
+// Convert data first
+final revenueInThousands = data.map((d) => {
+  ...d,
+  'revenue': d['revenue'] / 1000,
+}).toList();
+```
+
+## Tooltip Integration
+
+Tooltips automatically respect your axis formatting. When you format your Y-axis with currency, for example, tooltips will display `$1,234` instead of raw `1234.0` values - no additional configuration needed.
+
+## Performance Notes
+
+- Formatters are lightweight and efficient
+- String formatting occurs during rendering
+- Works seamlessly with animations and interactions
+
+Axis formatting enhances chart readability and provides professional, context-appropriate displays for any data visualization need.

--- a/example/lib/axis_formatting_demo.dart
+++ b/example/lib/axis_formatting_demo.dart
@@ -45,10 +45,10 @@ class AxisFormattingDemo extends StatelessWidget {
                   .theme(ChartTheme.defaultTheme())
                   .build(),
             ),
-            
+
             const SizedBox(height: 30),
-            
-            // Percentage formatting example  
+
+            // Percentage formatting example
             const Text(
               'Conversion Rate with Percentage Formatting',
               style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
@@ -64,13 +64,14 @@ class AxisFormattingDemo extends StatelessWidget {
                   .geomLine(strokeWidth: 3.0)
                   .geomPoint(size: 6.0)
                   .formatXAxis() // No formatting for X-axis
-                  .formatYAxis(suffix: '%', decimals: 1) // Percentage formatting
+                  .formatYAxis(
+                      suffix: '%', decimals: 1) // Percentage formatting
                   .theme(ChartTheme.defaultTheme())
                   .build(),
             ),
-            
+
             const SizedBox(height: 30),
-            
+
             // Dual-axis chart with different formatting
             const Text(
               'Dual-Axis Chart with Different Formatting',
@@ -87,16 +88,23 @@ class AxisFormattingDemo extends StatelessWidget {
                   .scaleYContinuous()
                   .scaleY2Continuous(min: 0, max: 25)
                   .geomBar() // Revenue bars (primary Y-axis)
-                  .geomLine(strokeWidth: 3.0, color: Colors.red, yAxis: YAxis.secondary) // Conversion line (secondary Y-axis)
+                  .geomLine(
+                      strokeWidth: 3.0,
+                      color: Colors.red,
+                      yAxis:
+                          YAxis.secondary) // Conversion line (secondary Y-axis)
                   .formatXAxis() // No formatting for X-axis
-                  .formatYAxis(prefix: '\$', decimals: 0) // Currency for primary Y-axis
-                  .formatY2Axis(suffix: '%', decimals: 1) // Percentage for secondary Y-axis
+                  .formatYAxis(
+                      prefix: '\$', decimals: 0) // Currency for primary Y-axis
+                  .formatY2Axis(
+                      suffix: '%',
+                      decimals: 1) // Percentage for secondary Y-axis
                   .theme(ChartTheme.defaultTheme())
                   .build(),
             ),
-            
+
             const SizedBox(height: 30),
-            
+
             // Custom formatting example
             const Text(
               'Custom Formatting with Japanese Yen',
@@ -106,22 +114,26 @@ class AxisFormattingDemo extends StatelessWidget {
             SizedBox(
               height: 300,
               child: CristalyseChart()
-                  .data(revenueData.map((d) => {
-                    'month': d['month'],
-                    'revenue_jpy': (d['revenue']! as double) * 150, // Convert to JPY
-                  }).toList())
+                  .data(revenueData
+                      .map((d) => {
+                            'month': d['month'],
+                            'revenue_jpy': (d['revenue']! as double) *
+                                150, // Convert to JPY
+                          })
+                      .toList())
                   .mapping(x: 'month', y: 'revenue_jpy')
                   .scaleXOrdinal()
                   .scaleYContinuous()
                   .geomBar()
                   .formatXAxis() // No formatting for X-axis
-                  .formatYAxis(prefix: 'JPY ', decimals: 0) // Japanese Yen (no decimals)
+                  .formatYAxis(
+                      prefix: 'JPY ', decimals: 0) // Japanese Yen (no decimals)
                   .theme(ChartTheme.defaultTheme())
                   .build(),
             ),
-            
+
             const SizedBox(height: 20),
-            
+
             // Information card
             Card(
               child: Padding(
@@ -131,14 +143,17 @@ class AxisFormattingDemo extends StatelessWidget {
                   children: [
                     const Text(
                       'Axis Formatting Features:',
-                      style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                      style:
+                          TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                     ),
                     const SizedBox(height: 8),
                     const Text('• Prefix support (e.g., \$, JPY, EUR)'),
                     const Text('• Suffix support (e.g., %, units, per item)'),
                     const Text('• Custom decimal places'),
-                    const Text('• Predefined formatters (currency, percentage)'),
-                    const Text('• Independent formatting for X, Y, and Y2 axes'),
+                    const Text(
+                        '• Predefined formatters (currency, percentage)'),
+                    const Text(
+                        '• Independent formatting for X, Y, and Y2 axes'),
                     const Text('• Works with all chart types'),
                     const SizedBox(height: 12),
                     const Text(
@@ -157,15 +172,18 @@ class AxisFormattingDemo extends StatelessWidget {
                         children: [
                           Text(
                             'chart.formatYAxis(prefix: "\$", decimals: 2)',
-                            style: TextStyle(fontFamily: 'monospace', fontSize: 12),
+                            style: TextStyle(
+                                fontFamily: 'monospace', fontSize: 12),
                           ),
                           Text(
                             'chart.formatYAxis(suffix: "%", decimals: 1)',
-                            style: TextStyle(fontFamily: 'monospace', fontSize: 12),
+                            style: TextStyle(
+                                fontFamily: 'monospace', fontSize: 12),
                           ),
                           Text(
                             'chart.formatYAxis(formatter: AxisFormatter.currency)',
-                            style: TextStyle(fontFamily: 'monospace', fontSize: 12),
+                            style: TextStyle(
+                                fontFamily: 'monospace', fontSize: 12),
                           ),
                         ],
                       ),

--- a/example/lib/axis_formatting_demo.dart
+++ b/example/lib/axis_formatting_demo.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:cristalyse/cristalyse.dart';
+
+class AxisFormattingDemo extends StatelessWidget {
+  const AxisFormattingDemo({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // Sample data for demonstrating formatting
+    final revenueData = [
+      {'month': 'Jan', 'revenue': 1500.50, 'conversion': 12.5},
+      {'month': 'Feb', 'revenue': 2800.75, 'conversion': 15.2},
+      {'month': 'Mar', 'revenue': 3200.25, 'conversion': 18.7},
+      {'month': 'Apr', 'revenue': 2900.00, 'conversion': 16.3},
+      {'month': 'May', 'revenue': 4100.80, 'conversion': 22.1},
+      {'month': 'Jun', 'revenue': 3800.45, 'conversion': 19.8},
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Axis Formatting Demo'),
+        backgroundColor: Colors.blueGrey,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Currency formatting example
+            const Text(
+              'Revenue Chart with Currency Formatting',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 10),
+            SizedBox(
+              height: 300,
+              child: CristalyseChart()
+                  .data(revenueData)
+                  .mapping(x: 'month', y: 'revenue')
+                  .scaleXOrdinal()
+                  .scaleYContinuous()
+                  .geomBar()
+                  .formatXAxis() // No formatting for X-axis (month names)
+                  .formatYAxis(prefix: '\$', decimals: 0) // Currency formatting
+                  .theme(ChartTheme.defaultTheme())
+                  .build(),
+            ),
+            
+            const SizedBox(height: 30),
+            
+            // Percentage formatting example  
+            const Text(
+              'Conversion Rate with Percentage Formatting',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 10),
+            SizedBox(
+              height: 300,
+              child: CristalyseChart()
+                  .data(revenueData)
+                  .mapping(x: 'month', y: 'conversion')
+                  .scaleXOrdinal()
+                  .scaleYContinuous()
+                  .geomLine(strokeWidth: 3.0)
+                  .geomPoint(size: 6.0)
+                  .formatXAxis() // No formatting for X-axis
+                  .formatYAxis(suffix: '%', decimals: 1) // Percentage formatting
+                  .theme(ChartTheme.defaultTheme())
+                  .build(),
+            ),
+            
+            const SizedBox(height: 30),
+            
+            // Dual-axis chart with different formatting
+            const Text(
+              'Dual-Axis Chart with Different Formatting',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 10),
+            SizedBox(
+              height: 300,
+              child: CristalyseChart()
+                  .data(revenueData)
+                  .mapping(x: 'month', y: 'revenue')
+                  .mappingY2('conversion')
+                  .scaleXOrdinal()
+                  .scaleYContinuous()
+                  .scaleY2Continuous(min: 0, max: 25)
+                  .geomBar() // Revenue bars (primary Y-axis)
+                  .geomLine(strokeWidth: 3.0, color: Colors.red, yAxis: YAxis.secondary) // Conversion line (secondary Y-axis)
+                  .formatXAxis() // No formatting for X-axis
+                  .formatYAxis(prefix: '\$', decimals: 0) // Currency for primary Y-axis
+                  .formatY2Axis(suffix: '%', decimals: 1) // Percentage for secondary Y-axis
+                  .theme(ChartTheme.defaultTheme())
+                  .build(),
+            ),
+            
+            const SizedBox(height: 30),
+            
+            // Custom formatting example
+            const Text(
+              'Custom Formatting with Japanese Yen',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 10),
+            SizedBox(
+              height: 300,
+              child: CristalyseChart()
+                  .data(revenueData.map((d) => {
+                    'month': d['month'],
+                    'revenue_jpy': (d['revenue']! as double) * 150, // Convert to JPY
+                  }).toList())
+                  .mapping(x: 'month', y: 'revenue_jpy')
+                  .scaleXOrdinal()
+                  .scaleYContinuous()
+                  .geomBar()
+                  .formatXAxis() // No formatting for X-axis
+                  .formatYAxis(prefix: 'JPY ', decimals: 0) // Japanese Yen (no decimals)
+                  .theme(ChartTheme.defaultTheme())
+                  .build(),
+            ),
+            
+            const SizedBox(height: 20),
+            
+            // Information card
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Axis Formatting Features:',
+                      style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                    const Text('• Prefix support (e.g., \$, JPY, EUR)'),
+                    const Text('• Suffix support (e.g., %, units, per item)'),
+                    const Text('• Custom decimal places'),
+                    const Text('• Predefined formatters (currency, percentage)'),
+                    const Text('• Independent formatting for X, Y, and Y2 axes'),
+                    const Text('• Works with all chart types'),
+                    const SizedBox(height: 12),
+                    const Text(
+                      'Usage Examples:',
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 4),
+                    Container(
+                      padding: const EdgeInsets.all(8),
+                      decoration: BoxDecoration(
+                        color: Colors.grey[100],
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      child: const Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'chart.formatYAxis(prefix: "\$", decimals: 2)',
+                            style: TextStyle(fontFamily: 'monospace', fontSize: 12),
+                          ),
+                          Text(
+                            'chart.formatYAxis(suffix: "%", decimals: 1)',
+                            style: TextStyle(fontFamily: 'monospace', fontSize: 12),
+                          ),
+                          Text(
+                            'chart.formatYAxis(formatter: AxisFormatter.currency)',
+                            style: TextStyle(fontFamily: 'monospace', fontSize: 12),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:cristalyse/cristalyse.dart';
 import 'package:cristalyse_example/chart_theme.dart';
 import 'package:flutter/material.dart';
 
+import 'axis_formatting_demo.dart';
 import 'graphs/area_chart.dart';
 import 'graphs/bar_chart.dart';
 import 'graphs/dual_axis_chart.dart';
@@ -114,7 +115,7 @@ class _ExampleHomeState extends State<ExampleHome>
   void initState() {
     super.initState();
     _tabController =
-        TabController(length: 12, vsync: this); // Updated to 12 tabs
+        TabController(length: 13, vsync: this); // Updated to 13 tabs
     _fabAnimationController = AnimationController(
       duration: const Duration(milliseconds: 300),
       vsync: this,
@@ -571,6 +572,7 @@ class _ExampleHomeState extends State<ExampleHome>
             Tab(text: 'Pie Chart'), // New pie chart tab
             Tab(text: 'Dual Y-Axis'),
             Tab(text: 'Export'), // New export tab
+            Tab(text: 'Axis Format'), // New axis formatting tab
           ],
         ),
       ),
@@ -745,6 +747,19 @@ class _ExampleHomeState extends State<ExampleHome>
                         'Scalability', '∞', 'Infinite Zoom', Colors.green),
                     _buildStatsCard(
                         'File Size', 'Small', 'Compact', Colors.purple),
+                  ],
+                ),
+                _buildChartPage(
+                  'Axis Label Formatting',
+                  'Format axis labels with prefix, suffix, and decimal places • Currency, percentage, and custom formatting',
+                  const AxisFormattingDemo(),
+                  [
+                    _buildStatsCard(
+                        'Currency', '\$1,234', 'Dollar Prefix', Colors.green),
+                    _buildStatsCard(
+                        'Percentage', '15.2%', 'Percent Suffix', Colors.blue),
+                    _buildStatsCard(
+                        'Custom', 'JPY 1500', 'No Decimals', Colors.orange),
                   ],
                 ),
               ],
@@ -1014,6 +1029,13 @@ class _ExampleHomeState extends State<ExampleHome>
           'Infinite zoom and professional quality output',
           'Small file sizes perfect for web and print',
           'Editable in design software and ideal for presentations'
+        ];
+      case 12: // Axis formatting demo
+        return [
+          'Currency formatting with prefix support (\$, JPY, EUR)',
+          'Percentage formatting with suffix and custom decimal places',
+          'Independent formatting for X, Y, and Y2 axes in dual-axis charts',
+          'Predefined formatters and custom formatting options'
         ];
       default:
         return [];

--- a/lib/cristalyse.dart
+++ b/lib/cristalyse.dart
@@ -1,5 +1,6 @@
 library;
 
+export 'src/core/axis_formatter.dart';
 export 'src/core/chart.dart';
 export 'src/core/geometry.dart';
 export 'src/core/scale.dart';

--- a/lib/src/core/axis_formatter.dart
+++ b/lib/src/core/axis_formatter.dart
@@ -20,7 +20,7 @@ class AxisFormatter {
   String format(dynamic value) {
     if (value is num) {
       final String numericString;
-      
+
       // Handle special double values
       if (value.isInfinite || value.isNaN) {
         numericString = value.toString();
@@ -35,7 +35,7 @@ class AxisFormatter {
           numericString = value.toStringAsFixed(1);
         }
       }
-      
+
       return '$prefix$numericString$suffix';
     } else if (value is String) {
       // For string values, add prefix/suffix
@@ -60,27 +60,28 @@ class AxisFormatter {
   }
 
   /// Common formatters for convenience
-  
+
   /// Currency formatter with $ prefix
   static const AxisFormatter currency = AxisFormatter(prefix: '\$');
-  
+
   /// Percentage formatter with % suffix
   static const AxisFormatter percentage = AxisFormatter(suffix: '%');
-  
+
   /// Currency formatter with custom prefix
-  static AxisFormatter currencyWithSymbol(String symbol) => 
+  static AxisFormatter currencyWithSymbol(String symbol) =>
       AxisFormatter(prefix: symbol);
-  
+
   /// Formatter with custom prefix and suffix
   static AxisFormatter custom({
     String prefix = '',
     String suffix = '',
     int? decimals,
-  }) => AxisFormatter(
-    prefix: prefix,
-    suffix: suffix,
-    decimals: decimals,
-  );
+  }) =>
+      AxisFormatter(
+        prefix: prefix,
+        suffix: suffix,
+        decimals: decimals,
+      );
 
   @override
   bool operator ==(Object other) {

--- a/lib/src/core/axis_formatter.dart
+++ b/lib/src/core/axis_formatter.dart
@@ -1,0 +1,101 @@
+/// Axis type enumeration for formatter selection
+enum AxisType { x, y, y2 }
+
+/// Formatter for axis labels with support for prefix, suffix, and # of decimal places
+class AxisFormatter {
+  final String prefix;
+  final String suffix;
+  final int? decimals;
+
+  const AxisFormatter({
+    this.prefix = '',
+    this.suffix = '',
+    this.decimals,
+  });
+
+  /// Default formatter (no changes to labels)
+  static const AxisFormatter defaultFormatter = AxisFormatter();
+
+  /// Format a value according to the instance configuration
+  String format(dynamic value) {
+    if (value is num) {
+      final String numericString;
+      
+      // Handle special double values
+      if (value.isInfinite || value.isNaN) {
+        numericString = value.toString();
+      } else if (decimals != null) {
+        // Use specified decimal places
+        numericString = value.toStringAsFixed(decimals!);
+      } else {
+        // Use default logic: integers without decimals, others with 1 decimal place
+        if (value == value.roundToDouble()) {
+          numericString = value.round().toString();
+        } else {
+          numericString = value.toStringAsFixed(1);
+        }
+      }
+      
+      return '$prefix$numericString$suffix';
+    } else if (value is String) {
+      // For string values, add prefix/suffix
+      return '$prefix$value$suffix';
+    } else {
+      // For any other types that may arise, return the value as-is
+      return value.toString();
+    }
+  }
+
+  /// Create a copy of this formatter with updated values
+  AxisFormatter copyWith({
+    String? prefix,
+    String? suffix,
+    int? decimals,
+  }) {
+    return AxisFormatter(
+      prefix: prefix ?? this.prefix,
+      suffix: suffix ?? this.suffix,
+      decimals: decimals ?? this.decimals,
+    );
+  }
+
+  /// Common formatters for convenience
+  
+  /// Currency formatter with $ prefix
+  static const AxisFormatter currency = AxisFormatter(prefix: '\$');
+  
+  /// Percentage formatter with % suffix
+  static const AxisFormatter percentage = AxisFormatter(suffix: '%');
+  
+  /// Currency formatter with custom prefix
+  static AxisFormatter currencyWithSymbol(String symbol) => 
+      AxisFormatter(prefix: symbol);
+  
+  /// Formatter with custom prefix and suffix
+  static AxisFormatter custom({
+    String prefix = '',
+    String suffix = '',
+    int? decimals,
+  }) => AxisFormatter(
+    prefix: prefix,
+    suffix: suffix,
+    decimals: decimals,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is AxisFormatter &&
+        other.prefix == prefix &&
+        other.suffix == suffix &&
+        other.decimals == decimals;
+  }
+
+  @override
+  int get hashCode => Object.hash(prefix, suffix, decimals);
+
+  @override
+  String toString() {
+    return 'AxisFormatter(prefix: "$prefix", suffix: "$suffix", decimals: $decimals)';
+  }
+}

--- a/lib/src/core/chart.dart
+++ b/lib/src/core/chart.dart
@@ -4,6 +4,7 @@ import '../export/chart_export.dart';
 import '../interaction/chart_interactions.dart';
 import '../themes/chart_theme.dart';
 import '../widgets/animated_chart_widget.dart';
+import 'axis_formatter.dart';
 import 'geometry.dart';
 import 'scale.dart';
 
@@ -37,6 +38,11 @@ class CristalyseChart {
   Curve _animationCurve = Curves.easeInOut;
 
   bool _coordFlipped = false;
+
+  // Axis formatters
+  AxisFormatter _xAxisFormatter = AxisFormatter.defaultFormatter;
+  AxisFormatter _yAxisFormatter = AxisFormatter.defaultFormatter;
+  AxisFormatter _y2AxisFormatter = AxisFormatter.defaultFormatter;
 
   /// Interaction configuration
   ChartInteraction _interaction = ChartInteraction.none;
@@ -429,6 +435,81 @@ class CristalyseChart {
     return this;
   }
 
+  /// Format X-axis labels
+  ///
+  /// Example:
+  /// ```dart
+  /// chart.formatXAxis(prefix: '\$', suffix: '', decimals: 2)
+  /// chart.formatXAxis(formatter: AxisFormatter.currency)
+  /// ```
+  CristalyseChart formatXAxis({
+    String? prefix,
+    String? suffix,
+    int? decimals,
+    AxisFormatter? formatter,
+  }) {
+    if (formatter != null) {
+      _xAxisFormatter = formatter;
+    } else {
+      _xAxisFormatter = AxisFormatter(
+        prefix: prefix ?? '',
+        suffix: suffix ?? '',
+        decimals: decimals,
+      );
+    }
+    return this;
+  }
+
+  /// Format Y-axis labels (primary/left axis)
+  ///
+  /// Example:
+  /// ```dart
+  /// chart.formatYAxis(prefix: '', suffix: '%', decimals: 1)
+  /// chart.formatYAxis(formatter: AxisFormatter.percentage)
+  /// ```
+  CristalyseChart formatYAxis({
+    String? prefix,
+    String? suffix,
+    int? decimals,
+    AxisFormatter? formatter,
+  }) {
+    if (formatter != null) {
+      _yAxisFormatter = formatter;
+    } else {
+      _yAxisFormatter = AxisFormatter(
+        prefix: prefix ?? '',
+        suffix: suffix ?? '',
+        decimals: decimals,
+      );
+    }
+    return this;
+  }
+
+  /// Format secondary Y-axis labels (right axis)
+  ///
+  /// Example:
+  /// ```dart
+  /// chart.formatY2Axis(prefix: 'JPY ', suffix: '', decimals: 0)
+  /// chart.formatY2Axis(formatter: AxisFormatter.currencyWithSymbol('€'))
+  /// ```
+  CristalyseChart formatY2Axis({
+    String? prefix,
+    String? suffix,
+    int? decimals,
+    AxisFormatter? formatter,
+  }) {
+    if (formatter != null) {
+      _y2AxisFormatter = formatter;
+    } else {
+      _y2AxisFormatter = AxisFormatter(
+        prefix: prefix ?? '',
+        suffix: suffix ?? '',
+        decimals: decimals,
+      );
+    }
+    return this;
+  }
+
   /// Export the chart as SVG image
   ///
   /// Example:
@@ -500,6 +581,9 @@ class CristalyseChart {
       animationCurve: _animationCurve,
       coordFlipped: _coordFlipped,
       interaction: _interaction,
+      xAxisFormatter: _xAxisFormatter,
+      yAxisFormatter: _yAxisFormatter,
+      y2AxisFormatter: _y2AxisFormatter,
     );
   }
 }

--- a/lib/src/widgets/animated_chart_widget.dart
+++ b/lib/src/widgets/animated_chart_widget.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
+import '../core/axis_formatter.dart';
 import '../core/geometry.dart';
 import '../core/scale.dart';
 import '../interaction/chart_interactions.dart';
@@ -31,6 +32,9 @@ class AnimatedCristalyseChartWidget extends StatefulWidget {
   final Curve animationCurve;
   final bool coordFlipped;
   final ChartInteraction interaction;
+  final AxisFormatter xAxisFormatter;
+  final AxisFormatter yAxisFormatter;
+  final AxisFormatter y2AxisFormatter;
 
   const AnimatedCristalyseChartWidget({
     super.key,
@@ -53,6 +57,9 @@ class AnimatedCristalyseChartWidget extends StatefulWidget {
     this.animationCurve = Curves.easeInOut,
     this.coordFlipped = false,
     this.interaction = ChartInteraction.none,
+    this.xAxisFormatter = AxisFormatter.defaultFormatter,
+    this.yAxisFormatter = AxisFormatter.defaultFormatter,
+    this.y2AxisFormatter = AxisFormatter.defaultFormatter,
   });
 
   @override
@@ -446,6 +453,9 @@ class _AnimatedCristalyseChartWidgetState
             theme: widget.theme,
             animationProgress: 1.0,
             coordFlipped: widget.coordFlipped,
+            xAxisFormatter: widget.xAxisFormatter,
+            yAxisFormatter: widget.yAxisFormatter,
+            y2AxisFormatter: widget.y2AxisFormatter,
           ),
           child: Container(),
         ),
@@ -482,6 +492,9 @@ class _AnimatedCristalyseChartWidgetState
       coordFlipped: widget.coordFlipped,
       panXDomain: _panXDomain,
       panYDomain: _panYDomain,
+      xAxisFormatter: widget.xAxisFormatter,
+      yAxisFormatter: widget.yAxisFormatter,
+      y2AxisFormatter: widget.y2AxisFormatter,
     );
 
     Widget chart = CustomPaint(painter: chartPainter, child: Container());
@@ -932,6 +945,9 @@ class _AnimatedChartPainter extends CustomPainter {
   final bool coordFlipped;
   final List<double>? panXDomain;
   final List<double>? panYDomain;
+  final AxisFormatter xAxisFormatter;
+  final AxisFormatter yAxisFormatter;
+  final AxisFormatter y2AxisFormatter;
 
   _AnimatedChartPainter({
     required this.data,
@@ -953,6 +969,9 @@ class _AnimatedChartPainter extends CustomPainter {
     this.coordFlipped = false,
     this.panXDomain,
     this.panYDomain,
+    required this.xAxisFormatter,
+    required this.yAxisFormatter,
+    required this.y2AxisFormatter,
   });
 
   @override
@@ -2265,7 +2284,7 @@ class _AnimatedChartPainter extends CustomPainter {
         paint,
       );
 
-      final label = _formatAxisLabel(tick);
+      final label = _formatAxisLabel(tick, AxisType.x);
       final textPainter = TextPainter(
         text: TextSpan(text: label, style: axisLabelStyle),
         textDirection: TextDirection.ltr,
@@ -2291,7 +2310,7 @@ class _AnimatedChartPainter extends CustomPainter {
         paint,
       );
 
-      final label = _formatAxisLabel(tick);
+      final label = _formatAxisLabel(tick, AxisType.y);
       final textPainter = TextPainter(
         text: TextSpan(text: label, style: axisLabelStyle),
         textDirection: TextDirection.ltr,
@@ -2318,7 +2337,7 @@ class _AnimatedChartPainter extends CustomPainter {
           paint,
         );
 
-        final label = _formatAxisLabel(tick);
+        final label = _formatAxisLabel(tick, AxisType.y2);
         final textPainter = TextPainter(
           text: TextSpan(
             text: label,
@@ -2518,7 +2537,7 @@ class _AnimatedChartPainter extends CustomPainter {
       final percentage = (value / total * 100).toStringAsFixed(1);
       labelText = '$category\n$percentage%';
     } else {
-      labelText = '$category\n${_formatAxisLabel(value)}';
+      labelText = '$category\n${_formatAxisLabel(value, AxisType.y)}';
     }
 
     final textPainter = TextPainter(
@@ -2553,16 +2572,21 @@ class _AnimatedChartPainter extends CustomPainter {
     textPainter.paint(canvas, labelOffset);
   }
 
-  String _formatAxisLabel(dynamic value) {
-    if (value is num) {
-      if (value == value.roundToDouble()) {
-        return value.round().toString();
-      } else {
-        return value.toStringAsFixed(1);
-      }
-    } else {
-      return value.toString();
+  String _formatAxisLabel(dynamic value, AxisType axisType) {
+    final AxisFormatter formatter;
+    switch (axisType) {
+      case AxisType.x:
+        formatter = xAxisFormatter;
+        break;
+      case AxisType.y:
+        formatter = yAxisFormatter;
+        break;
+      case AxisType.y2:
+        formatter = y2AxisFormatter;
+        break;
     }
+    
+    return formatter.format(value);
   }
 
   @override
@@ -2574,6 +2598,9 @@ class _AnimatedChartPainter extends CustomPainter {
         oldDelegate.coordFlipped != coordFlipped ||
         oldDelegate.y2Column != y2Column ||
         oldDelegate.pieValueColumn != pieValueColumn ||
-        oldDelegate.pieCategoryColumn != pieCategoryColumn;
+        oldDelegate.pieCategoryColumn != pieCategoryColumn ||
+        oldDelegate.xAxisFormatter != xAxisFormatter ||
+        oldDelegate.yAxisFormatter != yAxisFormatter ||
+        oldDelegate.y2AxisFormatter != y2AxisFormatter;
   }
 }

--- a/lib/src/widgets/animated_chart_widget.dart
+++ b/lib/src/widgets/animated_chart_widget.dart
@@ -2585,7 +2585,7 @@ class _AnimatedChartPainter extends CustomPainter {
         formatter = y2AxisFormatter;
         break;
     }
-    
+
     return formatter.format(value);
   }
 

--- a/test/axis_formatting_test.dart
+++ b/test/axis_formatting_test.dart
@@ -6,17 +6,17 @@ void main() {
     group('Basic formatting', () {
       test('default formatter should not modify values', () {
         const formatter = AxisFormatter.defaultFormatter;
-        
+
         // Test integers
         expect(formatter.format(42), equals('42'));
         expect(formatter.format(-5), equals('-5'));
         expect(formatter.format(0), equals('0'));
-        
+
         // Test floats
         expect(formatter.format(3.14159), equals('3.1'));
         expect(formatter.format(2.0), equals('2'));
         expect(formatter.format(-1.5), equals('-1.5'));
-        
+
         // Test strings
         expect(formatter.format('category'), equals('category'));
         expect(formatter.format(''), equals(''));
@@ -24,7 +24,7 @@ void main() {
 
       test('should handle prefix correctly', () {
         const formatter = AxisFormatter(prefix: '\$');
-        
+
         expect(formatter.format(100), equals('\$100'));
         expect(formatter.format(0), equals('\$0'));
         expect(formatter.format(-50), equals('\$-50'));
@@ -34,7 +34,7 @@ void main() {
 
       test('should handle suffix correctly', () {
         const formatter = AxisFormatter(suffix: '%');
-        
+
         expect(formatter.format(100), equals('100%'));
         expect(formatter.format(0), equals('0%'));
         expect(formatter.format(-50), equals('-50%'));
@@ -44,7 +44,7 @@ void main() {
 
       test('should handle both prefix and suffix', () {
         const formatter = AxisFormatter(prefix: '\$', suffix: ' USD');
-        
+
         expect(formatter.format(100), equals('\$100 USD'));
         expect(formatter.format(0), equals('\$0 USD'));
         expect(formatter.format(-50), equals('\$-50 USD'));
@@ -55,7 +55,7 @@ void main() {
     group('Decimal places formatting', () {
       test('should respect custom decimal places', () {
         const formatter = AxisFormatter(decimals: 0);
-        
+
         expect(formatter.format(3.14159), equals('3'));
         expect(formatter.format(2.9), equals('3'));
         expect(formatter.format(-1.7), equals('-2'));
@@ -64,7 +64,7 @@ void main() {
 
       test('should format with 2 decimal places', () {
         const formatter = AxisFormatter(decimals: 2);
-        
+
         expect(formatter.format(3.14159), equals('3.14'));
         expect(formatter.format(2.0), equals('2.00'));
         expect(formatter.format(-1.7), equals('-1.70'));
@@ -73,7 +73,7 @@ void main() {
 
       test('should format with 3 decimal places', () {
         const formatter = AxisFormatter(decimals: 3);
-        
+
         expect(formatter.format(3.14159), equals('3.142'));
         expect(formatter.format(2.0), equals('2.000'));
         expect(formatter.format(-1.7), equals('-1.700'));
@@ -85,7 +85,7 @@ void main() {
           suffix: '',
           decimals: 0,
         );
-        
+
         expect(formatter.format(1500.75), equals('JPY 1501'));
         expect(formatter.format(100.25), equals('JPY 100'));
       });
@@ -104,7 +104,8 @@ void main() {
         expect(AxisFormatter.percentage.format(0), equals('0%'));
       });
 
-      test('custom formatter should add JPY without decimals if set to do so', () {
+      test('custom formatter should add JPY without decimals if set to do so',
+          () {
         final jpyFormatter = AxisFormatter.custom(prefix: 'JPY ', decimals: 0);
         expect(jpyFormatter.format(1500), equals('JPY 1500'));
         expect(jpyFormatter.format(3.14), equals('JPY 3'));
@@ -114,7 +115,7 @@ void main() {
 
       test('currencyWithSymbol should create custom currency formatter', () {
         final euroFormatter = AxisFormatter.currencyWithSymbol('€');
-        
+
         expect(euroFormatter.format(100), equals('€100'));
         expect(euroFormatter.format(3.14), equals('€3.1'));
         expect(euroFormatter.format(0), equals('€0'));
@@ -126,7 +127,7 @@ void main() {
           suffix: ' per unit',
           decimals: 0,
         );
-        
+
         expect(formatter.format(1500), equals('JPY 1500 per unit'));
         expect(formatter.format(3.14159), equals('JPY 3 per unit'));
       });
@@ -135,54 +136,61 @@ void main() {
     group('Edge cases', () {
       test('should handle null and empty values gracefully', () {
         const formatter = AxisFormatter(prefix: '\$', suffix: '%');
-        
-        expect(formatter.format(null), equals('null'));  // Non-string, non-numeric values returned as-is
-        expect(formatter.format(''), equals('\$%'));     // Empty string still gets prefix/suffix
+
+        expect(formatter.format(null),
+            equals('null')); // Non-string, non-numeric values returned as-is
+        expect(formatter.format(''),
+            equals('\$%')); // Empty string still gets prefix/suffix
       });
 
       test('should handle very large numbers', () {
         const formatter = AxisFormatter(prefix: '\$', decimals: 2);
-        
+
         expect(formatter.format(1234567.89), equals('\$1234567.89'));
         expect(formatter.format(-9876543.21), equals('\$-9876543.21'));
       });
 
       test('should handle very small numbers', () {
         const formatter = AxisFormatter(suffix: '%', decimals: 4);
-        
+
         expect(formatter.format(0.0001), equals('0.0001%'));
         expect(formatter.format(0.00001), equals('0.0000%'));
       });
 
       test('should handle special double values', () {
         const formatter = AxisFormatter(prefix: '\$');
-        
+
         expect(formatter.format(double.infinity), equals('\$Infinity'));
-        expect(formatter.format(double.negativeInfinity), equals('\$-Infinity'));
+        expect(
+            formatter.format(double.negativeInfinity), equals('\$-Infinity'));
         expect(formatter.format(double.nan), equals('\$NaN'));
       });
     });
 
     group('Object methods', () {
       test('equality should work correctly', () {
-        const formatter1 = AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
-        const formatter2 = AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
+        const formatter1 =
+            AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
+        const formatter2 =
+            AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
         const formatter3 = AxisFormatter(prefix: '€', suffix: '%', decimals: 2);
-        
+
         expect(formatter1, equals(formatter2));
         expect(formatter1, isNot(equals(formatter3)));
       });
 
       test('hashCode should be consistent', () {
-        const formatter1 = AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
-        const formatter2 = AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
-        
+        const formatter1 =
+            AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
+        const formatter2 =
+            AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
+
         expect(formatter1.hashCode, equals(formatter2.hashCode));
       });
 
       test('toString should provide readable output', () {
         const formatter = AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
-        
+
         expect(formatter.toString(), contains('prefix'));
         expect(formatter.toString(), contains('suffix'));
         expect(formatter.toString(), contains('decimals'));
@@ -190,17 +198,17 @@ void main() {
 
       test('copyWith should create modified copies', () {
         const original = AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
-        
+
         final withNewPrefix = original.copyWith(prefix: '€');
         expect(withNewPrefix.prefix, equals('€'));
         expect(withNewPrefix.suffix, equals('%'));
         expect(withNewPrefix.decimals, equals(2));
-        
+
         final withNewSuffix = original.copyWith(suffix: ' USD');
         expect(withNewSuffix.prefix, equals('\$'));
         expect(withNewSuffix.suffix, equals(' USD'));
         expect(withNewSuffix.decimals, equals(2));
-        
+
         final withNewDecimals = original.copyWith(decimals: 0);
         expect(withNewDecimals.prefix, equals('\$'));
         expect(withNewDecimals.suffix, equals('%'));

--- a/test/axis_formatting_test.dart
+++ b/test/axis_formatting_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cristalyse/src/core/axis_formatter.dart';
+
+void main() {
+  group('AxisFormatter Tests', () {
+    group('Basic formatting', () {
+      test('default formatter should not modify values', () {
+        const formatter = AxisFormatter.defaultFormatter;
+        
+        // Test integers
+        expect(formatter.format(42), equals('42'));
+        expect(formatter.format(-5), equals('-5'));
+        expect(formatter.format(0), equals('0'));
+        
+        // Test floats
+        expect(formatter.format(3.14159), equals('3.1'));
+        expect(formatter.format(2.0), equals('2'));
+        expect(formatter.format(-1.5), equals('-1.5'));
+        
+        // Test strings
+        expect(formatter.format('category'), equals('category'));
+        expect(formatter.format(''), equals(''));
+      });
+
+      test('should handle prefix correctly', () {
+        const formatter = AxisFormatter(prefix: '\$');
+        
+        expect(formatter.format(100), equals('\$100'));
+        expect(formatter.format(0), equals('\$0'));
+        expect(formatter.format(-50), equals('\$-50'));
+        expect(formatter.format(3.14), equals('\$3.1'));
+        expect(formatter.format('text'), equals('\$text'));
+      });
+
+      test('should handle suffix correctly', () {
+        const formatter = AxisFormatter(suffix: '%');
+        
+        expect(formatter.format(100), equals('100%'));
+        expect(formatter.format(0), equals('0%'));
+        expect(formatter.format(-50), equals('-50%'));
+        expect(formatter.format(3.14), equals('3.1%'));
+        expect(formatter.format('high'), equals('high%'));
+      });
+
+      test('should handle both prefix and suffix', () {
+        const formatter = AxisFormatter(prefix: '\$', suffix: ' USD');
+        
+        expect(formatter.format(100), equals('\$100 USD'));
+        expect(formatter.format(0), equals('\$0 USD'));
+        expect(formatter.format(-50), equals('\$-50 USD'));
+        expect(formatter.format(3.14), equals('\$3.1 USD'));
+      });
+    });
+
+    group('Decimal places formatting', () {
+      test('should respect custom decimal places', () {
+        const formatter = AxisFormatter(decimals: 0);
+        
+        expect(formatter.format(3.14159), equals('3'));
+        expect(formatter.format(2.9), equals('3'));
+        expect(formatter.format(-1.7), equals('-2'));
+        expect(formatter.format(100), equals('100'));
+      });
+
+      test('should format with 2 decimal places', () {
+        const formatter = AxisFormatter(decimals: 2);
+        
+        expect(formatter.format(3.14159), equals('3.14'));
+        expect(formatter.format(2.0), equals('2.00'));
+        expect(formatter.format(-1.7), equals('-1.70'));
+        expect(formatter.format(100), equals('100.00'));
+      });
+
+      test('should format with 3 decimal places', () {
+        const formatter = AxisFormatter(decimals: 3);
+        
+        expect(formatter.format(3.14159), equals('3.142'));
+        expect(formatter.format(2.0), equals('2.000'));
+        expect(formatter.format(-1.7), equals('-1.700'));
+      });
+
+      test('should combine decimals with prefix and suffix', () {
+        const formatter = AxisFormatter(
+          prefix: 'JPY ',
+          suffix: '',
+          decimals: 0,
+        );
+        
+        expect(formatter.format(1500.75), equals('JPY 1501'));
+        expect(formatter.format(100.25), equals('JPY 100'));
+      });
+    });
+
+    group('Predefined formatters', () {
+      test('currency formatter should add dollar prefix', () {
+        expect(AxisFormatter.currency.format(100), equals('\$100'));
+        expect(AxisFormatter.currency.format(3.14), equals('\$3.1'));
+        expect(AxisFormatter.currency.format(0), equals('\$0'));
+      });
+
+      test('percentage formatter should add percent suffix', () {
+        expect(AxisFormatter.percentage.format(75), equals('75%'));
+        expect(AxisFormatter.percentage.format(3.14), equals('3.1%'));
+        expect(AxisFormatter.percentage.format(0), equals('0%'));
+      });
+
+      test('custom formatter should add JPY without decimals if set to do so', () {
+        final jpyFormatter = AxisFormatter.custom(prefix: 'JPY ', decimals: 0);
+        expect(jpyFormatter.format(1500), equals('JPY 1500'));
+        expect(jpyFormatter.format(3.14), equals('JPY 3'));
+        expect(jpyFormatter.format(0), equals('JPY 0'));
+        expect(jpyFormatter.format(1500.75), equals('JPY 1501'));
+      });
+
+      test('currencyWithSymbol should create custom currency formatter', () {
+        final euroFormatter = AxisFormatter.currencyWithSymbol('€');
+        
+        expect(euroFormatter.format(100), equals('€100'));
+        expect(euroFormatter.format(3.14), equals('€3.1'));
+        expect(euroFormatter.format(0), equals('€0'));
+      });
+
+      test('custom formatter should handle all parameters', () {
+        final formatter = AxisFormatter.custom(
+          prefix: 'JPY ',
+          suffix: ' per unit',
+          decimals: 0,
+        );
+        
+        expect(formatter.format(1500), equals('JPY 1500 per unit'));
+        expect(formatter.format(3.14159), equals('JPY 3 per unit'));
+      });
+    });
+
+    group('Edge cases', () {
+      test('should handle null and empty values gracefully', () {
+        const formatter = AxisFormatter(prefix: '\$', suffix: '%');
+        
+        expect(formatter.format(null), equals('null'));  // Non-string, non-numeric values returned as-is
+        expect(formatter.format(''), equals('\$%'));     // Empty string still gets prefix/suffix
+      });
+
+      test('should handle very large numbers', () {
+        const formatter = AxisFormatter(prefix: '\$', decimals: 2);
+        
+        expect(formatter.format(1234567.89), equals('\$1234567.89'));
+        expect(formatter.format(-9876543.21), equals('\$-9876543.21'));
+      });
+
+      test('should handle very small numbers', () {
+        const formatter = AxisFormatter(suffix: '%', decimals: 4);
+        
+        expect(formatter.format(0.0001), equals('0.0001%'));
+        expect(formatter.format(0.00001), equals('0.0000%'));
+      });
+
+      test('should handle special double values', () {
+        const formatter = AxisFormatter(prefix: '\$');
+        
+        expect(formatter.format(double.infinity), equals('\$Infinity'));
+        expect(formatter.format(double.negativeInfinity), equals('\$-Infinity'));
+        expect(formatter.format(double.nan), equals('\$NaN'));
+      });
+    });
+
+    group('Object methods', () {
+      test('equality should work correctly', () {
+        const formatter1 = AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
+        const formatter2 = AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
+        const formatter3 = AxisFormatter(prefix: '€', suffix: '%', decimals: 2);
+        
+        expect(formatter1, equals(formatter2));
+        expect(formatter1, isNot(equals(formatter3)));
+      });
+
+      test('hashCode should be consistent', () {
+        const formatter1 = AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
+        const formatter2 = AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
+        
+        expect(formatter1.hashCode, equals(formatter2.hashCode));
+      });
+
+      test('toString should provide readable output', () {
+        const formatter = AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
+        
+        expect(formatter.toString(), contains('prefix'));
+        expect(formatter.toString(), contains('suffix'));
+        expect(formatter.toString(), contains('decimals'));
+      });
+
+      test('copyWith should create modified copies', () {
+        const original = AxisFormatter(prefix: '\$', suffix: '%', decimals: 2);
+        
+        final withNewPrefix = original.copyWith(prefix: '€');
+        expect(withNewPrefix.prefix, equals('€'));
+        expect(withNewPrefix.suffix, equals('%'));
+        expect(withNewPrefix.decimals, equals(2));
+        
+        final withNewSuffix = original.copyWith(suffix: ' USD');
+        expect(withNewSuffix.prefix, equals('\$'));
+        expect(withNewSuffix.suffix, equals(' USD'));
+        expect(withNewSuffix.decimals, equals(2));
+        
+        final withNewDecimals = original.copyWith(decimals: 0);
+        expect(withNewDecimals.prefix, equals('\$'));
+        expect(withNewDecimals.suffix, equals('%'));
+        expect(withNewDecimals.decimals, equals(0));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Overview

This PR introduces axis label formatting capabilities to Cristalyse, enabling professional data visualization with currency symbols, percentage signs, custom prefixes/suffixes, and precise decimal control.

## Motivation

Current Cristalyse charts display raw numeric values on axes (e.g., `1234.567`, `0.15`), which can be unclear for business dashboards and financial charts. Users need professional formatting like `$1,234`, `15%`, or `JPY 1500` to create publication-ready visualizations.

## Features

### Core Functionality
- **Prefix/Suffix Support**: Add `$`, `%`, `JPY `, or any custom text to axis labels
- **Decimal Control**: Specify exact decimal places (`$1,234` vs `$1,234.50`)
- **Independent Axis Formatting**: Format X, Y, and Y2 axes differently in dual-axis charts
- **Automatic Tooltip Integration**: Tooltips already respect axis formatting without additional configuration

### API Design

```dart
// Simple formatting
CristalyseChart()
  .formatYAxis(prefix: '$', decimals: 0)        // $1234
  .formatYAxis(suffix: '%', decimals: 1)        // 15.2%

// Predefined formatters
.formatYAxis(formatter: AxisFormatter.currency)     // $100
.formatYAxis(formatter: AxisFormatter.percentage)   // 75%

// Custom formatters
.formatYAxis(formatter: AxisFormatter.custom(
  prefix: 'JPY ', 
  decimals: 0
))  // JPY 1500

// Dual-axis formatting
.formatYAxis(prefix: '$', decimals: 0)              // Left: $1234  
.formatY2Axis(suffix: '%', decimals: 1)             // Right: 15.2%
```

### Use Cases
- **Financial Dashboards**: Revenue charts with currency formatting
- **Performance Metrics**: Conversion rates with percentage formatting  
- **International Business**: Multi-currency support (USD, EUR, JPY)
- **Dual-Axis Charts**: Independent formatting for different metric types

## Implementation Details

### New Classes
- **`AxisFormatter`**: Core formatter with prefix, suffix, and decimal options
- **`AxisType` enum**: Type-safe axis selection (x, y, y2)

### Chart Integration
- Added `formatXAxis()`, `formatYAxis()`, `formatY2Axis()` methods to `CristalyseChart`
- Automatic formatting in axis rendering and tooltip display
- Backward compatible - existing charts unchanged. Private method `_formatAxisLabel()`changed  in `AnimatedChartPainter` & existing formatting logic moved to default case in AxisFormatter

### Architecture
- Clean separation: formatting logic in core, rendering in widgets
- Consistent with library patterns (similar to `ChartTheme`, `DefaultTooltips`)
- Extensible design for future formatting needs

## Examples

### Business Dashboard
```dart
CristalyseChart()
  .data(monthlyData)
  .mapping(x: 'month', y: 'revenue')
  .mappingY2('conversion_rate')
  .geomBar()
  .geomLine(yAxis: YAxis.secondary, color: Colors.red)
  .formatYAxis(prefix: '$', suffix: 'K', decimals: 0)  // $125K
  .formatY2Axis(suffix: '%', decimals: 1)              // 15.2%
  .build()
```

### International Sales
```dart
CristalyseChart()
  .data(regionalData)
  .mapping(x: 'region', y: 'revenue_jpy')
  .geomBar()
  .formatYAxis(formatter: AxisFormatter.custom(
    prefix: 'JPY ',
    decimals: 0,
  ))  // JPY 150000
  .build()
```

## Testing

- **21 comprehensive unit tests** covering all formatting scenarios
- **Edge case handling**: infinity, NaN, null values
- **Integration tests**: Works with existing chart types and themes
- **Visual demo**: Complete example app showing all features

## Documentation

- **Feature guide**: `/doc/features/axis-formatting.mdx`
- **Working Example**: Example app now includes Axis Formatting demo
- **API reference**: Full method documentation with examples
- **Best practices**: Decimal place recommendations, international considerations
- **Integration examples**: Dual-axis charts, tooltip behavior

## Backward Compatibility

✅ **Fully backward compatible**
- Existing charts continue to work unchanged
- New formatting is opt-in via explicit method calls
- Default behavior preserved (no formatting applied besides the former default logic)

## Performance

- Lightweight string operations during rendering
- No impact on data processing or chart generation
- Works seamlessly with animations and interactions

## Files Changed

### Core Implementation
- `lib/src/core/axis_formatter.dart` - New formatter class and AxisType enum
- `lib/src/core/chart.dart` - Added formatting methods
- `lib/src/widgets/animated_chart_widget.dart` - Integrated formatting into rendering

### Testing & Documentation  
- `test/axis_formatting_test.dart` - Unit test suite
- `doc/features/axis-formatting.mdx` - Complete user guide
- `example/lib/axis_formatting_demo.dart` - Visual demonstration

### Integration
- `lib/cristalyse.dart` - Export new classes
- `example/lib/main.dart` - Added demo to example app

## Demo

Run the example app and navigate to the "Axis Format" tab to see:
- Currency formatting ($1,234)
- Percentage formatting (15.2%)
- Custom JPY formatting (JPY 1500)  

## Request for Review

1. API design - Is the method naming and parameter structure intuitive to you as the library author?
2. Architecture - Does the separation between core formatting and widget rendering make sense?
3. Documentation - Are the examples and best practices helpful?
4. Performance - Any concerns with the rendering integration?

Looking forward to feedback and any suggestions for refinement!