### PR TITLE
 Add callback-based label formatting system

### DIFF
--- a/doc/advanced/scales.mdx
+++ b/doc/advanced/scales.mdx
@@ -75,6 +75,150 @@ CristalyseChart()
   .build()
 ```
 
+## Label Formatting
+
+Transform axis labels by passing a callback to the `labels` parameter on any axis scale that takes any number and returns a string.
+
+### Direct NumberFormat Usage
+
+For simple cases, you can use `NumberFormat` from Dart's `intl` package:
+
+```dart
+import 'package:intl/intl.dart';
+
+// Revenue chart with currency formatting
+CristalyseChart()
+  .data(salesData)
+  .mapping(x: 'quarter', y: 'revenue')
+  .scaleYContinuous(labels: NumberFormat.simpleCurrency().format) // $1,234.56
+  .build()
+
+// Conversion rate chart with percentage formatting
+CristalyseChart()
+  .data(conversionData)
+  .mapping(x: 'month', y: 'rate')
+  .scaleYContinuous(labels: NumberFormat.percentPattern().format) // 23%
+  .build()
+
+// User growth chart with compact formatting
+CristalyseChart()
+  .data(userGrowthData)
+  .mapping(x: 'date', y: 'users')
+  .scaleYContinuous(labels: NumberFormat.compact().format) // 1.2K, 1.5M
+  .build()
+```
+
+### Custom Callbacks for Advanced Cases
+
+When you need custom logic beyond NumberFormat, use a factory pattern to create a callback based on that logic.
+
+```dart
+// Create formatter once based on passed locale, reuse callback
+static String Function(num) createCurrencyFormatter({String locale = 'en_US'}) {
+  final formatter = NumberFormat.simpleCurrency(locale: locale); // Created once
+  return (num value) => formatter.format(value); // Reused callback
+}
+
+// Usage
+final currencyLabels = createCurrencyFormatter();
+// uses default here, but could internationalize
+
+// Revenue chart with currency formatting
+CristalyseChart()
+  .data(salesData)
+  .mapping(x: 'quarter', y: 'revenue')
+  .scaleYContinuous(labels: currencyLabels) // pass callback
+  .build()
+```
+
+#### Conditional Formatting (Value-Based Logic)
+
+```dart
+// Time duration formatting (seconds to human readable)
+static String Function(num) createDurationFormatter() {
+  return (num seconds) {
+    final roundedSeconds = seconds.round(); // Round to nearest second first
+    
+    if (roundedSeconds >= 3600) {
+      final hours = roundedSeconds / 3600;
+      if (hours == hours.round()) {
+        return '${hours.round()}h';  // Clean: "1h", "2h", "24h"
+      }
+      return '${hours.toStringAsFixed(1)}h';  // Decimal: "1.5h", "2.3h"
+    } else if (roundedSeconds >= 60) {
+      final minutes = (roundedSeconds / 60).round();
+      return '${minutes}m';  // "1m", "30m", "59m"
+    }
+    return '${roundedSeconds}s';  // "5s", "30s", "59s"
+  };
+}
+
+final usageLabels = createDurationFormatter();
+
+CristalyseChart()
+  .data(usageData)
+  .mapping(x: 'day', y: 'usage')
+  .scaleYContinuous(labels: usageLabels) // pass callback
+  .build()
+```
+
+#### Chart-Optimized Formatting (Clean Integers)
+
+```dart
+// Implement chart-friendly integer/decimal distinction w/ NumberFormat
+static String Function(num) createChartCurrencyFormatter() {
+  final formatter = NumberFormat.simpleCurrency(locale: 'en_US');
+  return (num value) {
+    if (value == value.roundToDouble()) {
+      return formatter.format(value).replaceAll('.00', ''); // $42
+    }
+    return formatter.format(value); // $42.50
+  };
+}
+
+final currencyLabels = createChartCurrencyFormatter();
+
+CristalyseChart()
+  .data(salesData)
+  .mapping(x: 'quarter', y: 'revenue')
+  .scaleYContinuous(labels: currencyLabels)
+  .build()
+```
+
+#### Business Logic Formatting
+
+```dart
+// Handle negative values differently (P&L charts)
+static String Function(num) createProfitLossFormatter() {
+  return (num value) {
+    final abs = value.abs();
+    final formatted = NumberFormat.compact().format(abs);
+    return value >= 0 ? '$formatted' : '($formatted)';
+  };
+}
+
+final currencyLabels = createProfitLossFormatter();
+
+CristalyseChart()
+  .data(salesData)
+  .mapping(x: 'quarter', y: 'revenue')
+  .scaleYContinuous(labels: currencyLabels)
+  .build()
+
+// Custom units (basis points for finance - converts decimal rates to bp)
+static String Function(num) createBasisPointFormatter() {
+  return (num value) => '${(value * 10000).toStringAsFixed(0)}bp';
+}
+
+final bpLabels = createBasisPointFormatter();
+
+CristalyseChart()
+  .data(yieldData) // Data has decimal rates like 0.0025, 0.0150
+  .mapping(x: 'maturity', y: 'yield_rate') // yield_rate is decimal (0.0025 = 25bp)
+  .scaleYContinuous(labels: bpLabels) // Converts 0.0025 → "25bp"
+  .build()
+```
+
 ## Scale Customization
 
 Customize scales to fit your data representation needs:
@@ -84,7 +228,7 @@ CristalyseChart()
   .data(data)
   .mapping(x: 'day', y: 'hours')
   .scaleXOrdinal()
-  .scaleYContinuous(min: 0, max: 24) // Range of working hours per day
+  .scaleYContinuous(min: 0, max: 24, labels: (v) => '${v}h') // Custom hour labels
   .build()
 ```
 

--- a/doc/advanced/scales.mdx
+++ b/doc/advanced/scales.mdx
@@ -190,10 +190,11 @@ CristalyseChart()
 ```dart
 // Handle negative values differently (P&L charts)
 static String Function(num) createProfitLossFormatter() {
+  final formatter = NumberFormat.compact(); // Created once
   return (num value) {
     final abs = value.abs();
-    final formatted = NumberFormat.compact().format(abs);
-    return value >= 0 ? '$formatted' : '($formatted)';
+    final formatted = formatter.format(abs); // Reuse formatter
+    return value >= 0 ? formatted : '($formatted)';
   };
 }
 

--- a/doc/charts/pie-charts.mdx
+++ b/doc/charts/pie-charts.mdx
@@ -210,6 +210,88 @@ CristalyseChart()
   .build()
 ```
 
+## Label Formatting
+
+Transform pie chart labels by passing a callback to the `labels` parameter.
+
+### Simple Custom Labels
+
+For basic formatting, you can use a simple callback:
+
+```dart
+CristalyseChart()
+  .data(salesData)
+  .mappingPie(value: 'revenue', category: 'region')
+  .geomPie(
+    outerRadius: 150,
+    showLabels: true,
+    showPercentages: false,
+    labels: (value) => '\$${value}K', // $450K
+  )
+  .build()
+```
+
+### Using NumberFormat
+
+For robust, locale-aware formatting, use NumberFormat:
+
+```dart
+import 'package:intl/intl.dart';
+
+// Currency formatting
+CristalyseChart()
+  .data(revenueData)
+  .mappingPie(value: 'revenue', category: 'department')
+  .geomPie(
+    outerRadius: 150,
+    showLabels: true,
+    showPercentages: false,
+    labels: NumberFormat.simpleCurrency().format, // $1,234.56
+  )
+  .build()
+
+// Compact user counts
+CristalyseChart()
+  .data(userData)
+  .mappingPie(value: 'users', category: 'platform')
+  .geomPie(
+    outerRadius: 150,
+    showLabels: true,
+    showPercentages: false,
+    labels: NumberFormat.compact().format, // 1.2K
+  )
+  .build()
+```
+
+### Percentage Formatting
+
+When `showPercentages: true`, your callback receives ratio values (0.0-1.0):
+
+```dart
+// Default percentage formatting
+CristalyseChart()
+  .data(surveyData)
+  .mappingPie(value: 'responses', category: 'rating')
+  .geomPie(
+    outerRadius: 150,
+    showLabels: true,
+    showPercentages: true, // Uses NumberFormat.percentPattern()
+  )
+  .build()
+
+// Custom percentage with NumberFormat
+CristalyseChart()
+  .data(surveyData)
+  .mappingPie(value: 'responses', category: 'rating')
+  .geomPie(
+    outerRadius: 150,
+    showLabels: true,
+    showPercentages: true,
+    labels: NumberFormat.percentPattern().format, // 23%
+  )
+  .build()
+```
+
 ## Real-World Examples
 
 ### E-commerce Sales by Category

--- a/doc/quickstart.mdx
+++ b/doc/quickstart.mdx
@@ -97,6 +97,36 @@ class MyFirstChart extends StatelessWidget {
   <em>Your first chart - clean, responsive, and cross-platform</em>
 </div>
 
+## Formatting Axis Labels
+
+You'll often want formatted axis labels.
+
+The `labels` parameter takes any function that converts a number to a string:
+
+```dart
+CristalyseChart()
+  .data(salesData)
+  .mapping(x: 'quarter', y: 'revenue')
+  .geomBar()
+  .scaleYContinuous(labels: (value) => '\$${value}') // $150
+  .scaleXOrdinal()
+  .build()
+```
+
+For robust, locale-aware formatting, use NumberFormat:
+
+```dart
+import 'package:intl/intl.dart';
+
+CristalyseChart()
+  .data(salesData)
+  .mapping(x: 'quarter', y: 'revenue')
+  .geomBar()
+  .scaleYContinuous(labels: NumberFormat.simpleCurrency().format) // $1,234.56
+  .scaleXOrdinal()
+  .build()
+```
+
 ## Understanding the Grammar
 
 Cristalyse follows the **Grammar of Graphics** pattern:

--- a/example/lib/graphs/dual_axis_chart.dart
+++ b/example/lib/graphs/dual_axis_chart.dart
@@ -41,9 +41,15 @@ Widget buildDualAxisTab(ChartTheme currentTheme,
                       : Colors.orange,
                   yAxis: YAxis.secondary) // Uses right Y-axis
               .scaleXOrdinal()
-              .scaleYContinuous(min: 0) // Left Y-axis (revenue)
+              .scaleYContinuous(
+                  min: 0,
+                  labels: (value) =>
+                      '\$${value.toStringAsFixed(0)}K') // Revenue in $K format
               .scaleY2Continuous(
-                  min: 0, max: 30) // Right Y-axis (percentage, adjusted range)
+                  min: 0,
+                  max: 30,
+                  labels: (value) =>
+                      '${value.toStringAsFixed(1)}%') // Conversion rates as %, adjusted range
               .theme(currentTheme)
               .animate(
                   duration: const Duration(milliseconds: 1500),
@@ -52,7 +58,7 @@ Widget buildDualAxisTab(ChartTheme currentTheme,
         ),
         const SizedBox(height: 16),
         const Text(
-            '• Bars show revenue (left Y-axis in \$k)\n• Line shows conversion rate (right Y-axis in %)\n• Two independent scales for different data ranges\n• Perfect for correlating volume vs efficiency metrics'),
+            '• Bars show revenue (left Y-axis in \$K format)\n• Line shows conversion rate (right Y-axis in %)\n• Two independent scales for different data ranges\n• Perfect for correlating volume vs efficiency metrics'),
       ],
     ),
   );

--- a/example/lib/graphs/grouped_bar.dart
+++ b/example/lib/graphs/grouped_bar.dart
@@ -1,5 +1,6 @@
 import 'package:cristalyse/cristalyse.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 Widget buildGroupedBarTab(ChartTheme currentTheme,
     List<Map<String, dynamic>> data, double sliderValue) {
@@ -8,7 +9,12 @@ Widget buildGroupedBarTab(ChartTheme currentTheme,
     child: Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text('Grouped Bar Chart'),
+        const Text('Product Performance by Quarter'),
+        const SizedBox(height: 8),
+        const Text(
+          'Multiple product lines compared side-by-side with currency formatting',
+          style: TextStyle(fontSize: 12, color: Colors.grey),
+        ),
         const SizedBox(height: 16),
         SizedBox(
           height: 400,
@@ -20,7 +26,11 @@ Widget buildGroupedBarTab(ChartTheme currentTheme,
                   style: BarStyle.grouped,
                   alpha: 0.9)
               .scaleXOrdinal()
-              .scaleYContinuous(min: 0)
+              .scaleYContinuous(
+                min: 0,
+                labels: NumberFormat.simpleCurrency()
+                    .format, // Direct NumberFormat usage
+              )
               .theme(currentTheme)
               .animate(
                   duration: const Duration(milliseconds: 1200),
@@ -29,7 +39,7 @@ Widget buildGroupedBarTab(ChartTheme currentTheme,
         ),
         const SizedBox(height: 16),
         const Text(
-            '• Multiple series grouped side-by-side\n• Color mapping for different products\n• Coordinated group animation'),
+            '• Multiple series grouped side-by-side\n• Uses direct NumberFormat.simpleCurrency()\n• Color mapping for different products\n• Coordinated group animation'),
       ],
     ),
   );

--- a/example/lib/graphs/horizontal_bar_chart.dart
+++ b/example/lib/graphs/horizontal_bar_chart.dart
@@ -9,6 +9,11 @@ Widget buildHorizontalBarTab(ChartTheme currentTheme,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const Text('Horizontal Bar Chart'),
+        const SizedBox(height: 8),
+        const Text(
+          'Team headcount by department',
+          style: TextStyle(fontSize: 12, color: Colors.grey),
+        ),
         const SizedBox(height: 16),
         SizedBox(
           height: 400,
@@ -18,7 +23,11 @@ Widget buildHorizontalBarTab(ChartTheme currentTheme,
               .geomBar(width: sliderValue.clamp(0.1, 1.0))
               .coordFlip()
               .scaleXOrdinal()
-              .scaleYContinuous(min: 0)
+              .scaleYContinuous(
+                min: 0,
+                labels: (value) =>
+                    '${value.round()}', // Clean whole numbers for headcount
+              )
               .theme(currentTheme)
               .animate(
                   duration: const Duration(milliseconds: 1000),
@@ -27,7 +36,7 @@ Widget buildHorizontalBarTab(ChartTheme currentTheme,
         ),
         const SizedBox(height: 16),
         const Text(
-            '• Bars grow from left to right\n• Categorical Y-axis for departments\n• Great for ranking data'),
+            '• Bars grow from left to right\n• Categorical Y-axis for departments\n• Clean whole number formatting for headcount\n• Great for ranking data'),
       ],
     ),
   );

--- a/example/lib/graphs/pie_chart.dart
+++ b/example/lib/graphs/pie_chart.dart
@@ -1,13 +1,14 @@
 import 'package:cristalyse/cristalyse.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 Widget buildPieChartTab(ChartTheme currentTheme,
     List<Map<String, dynamic>> data, double sliderValue) {
-  // Create pie chart specific data
+  // Create pie chart specific data with realistic revenue numbers
   final pieData = [
-    {'category': 'Mobile', 'revenue': 45.2, 'users': 1200},
-    {'category': 'Desktop', 'revenue': 32.8, 'users': 800},
-    {'category': 'Tablet', 'revenue': 22.0, 'users': 600},
+    {'category': 'Mobile', 'revenue': 450000, 'users': 1200},
+    {'category': 'Desktop', 'revenue': 328000, 'users': 800},
+    {'category': 'Tablet', 'revenue': 220000, 'users': 600},
   ];
 
   return SingleChildScrollView(
@@ -15,7 +16,7 @@ Widget buildPieChartTab(ChartTheme currentTheme,
     child: Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text('Animated Pie Chart'),
+        const Text('Revenue Distribution - Percentage Display'),
         const SizedBox(height: 16),
         SizedBox(
           height: 400,
@@ -28,7 +29,7 @@ Widget buildPieChartTab(ChartTheme currentTheme,
                 strokeWidth: 2.0,
                 strokeColor: Colors.white,
                 showLabels: true,
-                showPercentages: true,
+                showPercentages: true, // Show default percentage formatting
               )
               .theme(currentTheme)
               .animate(
@@ -40,7 +41,8 @@ Widget buildPieChartTab(ChartTheme currentTheme,
         const Text(
             '• Slices animate in with staggered timing\n• Percentages shown on labels\n• Smooth elastic animation curve'),
         const SizedBox(height: 32),
-        const Text('Donut Chart Example'),
+        const Text(
+            'User Distribution - Donut Chart with Compact Number Formatting'),
         const SizedBox(height: 16),
         SizedBox(
           height: 400,
@@ -53,7 +55,9 @@ Widget buildPieChartTab(ChartTheme currentTheme,
                 strokeWidth: 3.0,
                 strokeColor: Colors.white,
                 showLabels: true,
-                showPercentages: false, // Show actual values instead
+                showPercentages: false, // Show formatted user counts instead
+                labels:
+                    NumberFormat.compact().format, // Direct NumberFormat usage
               )
               .theme(currentTheme)
               .animate(
@@ -63,7 +67,7 @@ Widget buildPieChartTab(ChartTheme currentTheme,
         ),
         const SizedBox(height: 16),
         const Text(
-            '• Donut chart with inner radius\n• Shows actual values instead of percentages\n• Different animation curve'),
+            '• Donut chart with inner radius\n• Shows actual values instead of percentages\n• Different animation curve\n• Uses NumberFormat.compact() formatting'),
       ],
     ),
   );

--- a/example/lib/graphs/stacked_bar_chart.dart
+++ b/example/lib/graphs/stacked_bar_chart.dart
@@ -1,5 +1,6 @@
 import 'package:cristalyse/cristalyse.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 Widget buildStackedBarTab(ChartTheme currentTheme,
     List<Map<String, dynamic>> data, double sliderValue) {
@@ -8,7 +9,12 @@ Widget buildStackedBarTab(ChartTheme currentTheme,
     child: Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text('Stacked Bar Chart'),
+        const Text('Revenue Breakdown by Category'),
+        const SizedBox(height: 8),
+        const Text(
+          'Stacked segments showing part-to-whole relationships with currency formatting',
+          style: TextStyle(fontSize: 12, color: Colors.grey),
+        ),
         const SizedBox(height: 16),
         SizedBox(
           height: 400,
@@ -20,7 +26,11 @@ Widget buildStackedBarTab(ChartTheme currentTheme,
                   style: BarStyle.stacked, // This is the key!
                   alpha: 0.9)
               .scaleXOrdinal()
-              .scaleYContinuous(min: 0)
+              .scaleYContinuous(
+                min: 0,
+                labels: NumberFormat.simpleCurrency()
+                    .format, // Direct NumberFormat usage
+              )
               .theme(currentTheme)
               .animate(
                   duration: const Duration(milliseconds: 1400),
@@ -29,7 +39,7 @@ Widget buildStackedBarTab(ChartTheme currentTheme,
         ),
         const SizedBox(height: 16),
         const Text(
-            '• Segments stack on top of each other\n• Each color represents a different category\n• Great for showing part-to-whole relationships\n• Animated segment-by-segment building'),
+            '• Segments stack on top of each other\n• Each color represents a different category\n• Direct NumberFormat.simpleCurrency() usage\n• Great for showing part-to-whole relationships\n• Animated segment-by-segment building'),
       ],
     ),
   );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -976,6 +976,7 @@ class _ExampleHomeState extends State<ExampleHome>
       case 6: // Grouped bars
         return [
           'Side-by-side comparison of multiple data series',
+          'Clean currency formatting for financial comparisons',
           'Coordinated group animations with smooth timing',
           'Automatic legend generation from color mappings',
           'Perfect for product or regional comparisons'
@@ -998,7 +999,7 @@ class _ExampleHomeState extends State<ExampleHome>
         return [
           'Smooth slice animations with staggered timing',
           'Donut chart support with configurable inner radius',
-          'Smart label positioning with percentage display',
+          'Smart label positioning with formatting',
           'Exploded slices for emphasis and visual impact'
         ];
       case 10: // Dual Y-axis

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   cristalyse:
     path: ../
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:

--- a/lib/cristalyse.dart
+++ b/lib/cristalyse.dart
@@ -3,6 +3,7 @@ library;
 export 'src/core/chart.dart';
 export 'src/core/geometry.dart';
 export 'src/core/scale.dart';
+export 'src/core/label_formatter.dart';
 export 'src/export/chart_export.dart';
 export 'src/interaction/chart_interactions.dart';
 export 'src/interaction/interaction_detector.dart';

--- a/lib/src/core/chart.dart
+++ b/lib/src/core/chart.dart
@@ -6,6 +6,7 @@ import '../themes/chart_theme.dart';
 import '../widgets/animated_chart_widget.dart';
 import 'geometry.dart';
 import 'scale.dart';
+import 'label_formatter.dart';
 
 /// Main chart class implementing grammar of graphics API
 class CristalyseChart {
@@ -210,6 +211,7 @@ class CristalyseChart {
   ///   innerRadius: 40.0, // For donut chart
   ///   showLabels: true,
   ///   strokeWidth: 2.0,
+  ///   labels: (value) => NumberFormat.currency(symbol: '$').format(value),
   /// )
   /// ```
   CristalyseChart geomPie({
@@ -224,6 +226,7 @@ class CristalyseChart {
     bool? showPercentages,
     bool? explodeSlices,
     double? explodeDistance,
+    LabelCallback? labels,
   }) {
     _geometries.add(
       PieGeometry(
@@ -238,20 +241,23 @@ class CristalyseChart {
         showPercentages: showPercentages ?? true,
         explodeSlices: explodeSlices ?? false,
         explodeDistance: explodeDistance ?? 10.0,
+        labelFormatter: labels,
       ),
     );
     return this;
   }
 
   /// Configure continuous X scale
-  CristalyseChart scaleXContinuous({double? min, double? max}) {
-    _xScale = LinearScale(min: min, max: max);
+  CristalyseChart scaleXContinuous(
+      {double? min, double? max, LabelCallback? labels}) {
+    _xScale = LinearScale(min: min, max: max, labelFormatter: labels);
     return this;
   }
 
   /// Configure continuous Y scale (primary/left axis)
-  CristalyseChart scaleYContinuous({double? min, double? max}) {
-    _yScale = LinearScale(min: min, max: max);
+  CristalyseChart scaleYContinuous(
+      {double? min, double? max, LabelCallback? labels}) {
+    _yScale = LinearScale(min: min, max: max, labelFormatter: labels);
     return this;
   }
 
@@ -261,20 +267,21 @@ class CristalyseChart {
   /// ```dart
   /// chart.scaleY2Continuous(min: 0, max: 100) // For percentage data
   /// ```
-  CristalyseChart scaleY2Continuous({double? min, double? max}) {
-    _y2Scale = LinearScale(min: min, max: max);
+  CristalyseChart scaleY2Continuous(
+      {double? min, double? max, LabelCallback? labels}) {
+    _y2Scale = LinearScale(min: min, max: max, labelFormatter: labels);
     return this;
   }
 
   /// Configure categorical X scale (useful for bar charts)
-  CristalyseChart scaleXOrdinal() {
-    _xScale = OrdinalScale();
+  CristalyseChart scaleXOrdinal({LabelCallback? labels}) {
+    _xScale = OrdinalScale(labelFormatter: labels);
     return this;
   }
 
   /// Configure categorical Y scale
-  CristalyseChart scaleYOrdinal() {
-    _yScale = OrdinalScale();
+  CristalyseChart scaleYOrdinal({LabelCallback? labels}) {
+    _yScale = OrdinalScale(labelFormatter: labels);
     return this;
   }
 

--- a/lib/src/core/geometry.dart
+++ b/lib/src/core/geometry.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart' as intl;
+import 'label_formatter.dart';
 
 /// Enum for specifying which Y-axis to use
 enum YAxis { primary, secondary }
@@ -106,6 +108,9 @@ class AreaGeometry extends Geometry {
 
 /// Pie geometry for pie and donut charts
 class PieGeometry extends Geometry {
+  /// Static formatter as a default; don't create NumberFormat on every label render
+  static final _defaultPercentageFormatter = intl.NumberFormat.percentPattern();
+
   final double innerRadius; // For donut charts (0.0 for full pie)
   final double outerRadius;
   final Color? strokeColor;
@@ -117,6 +122,7 @@ class PieGeometry extends Geometry {
   final bool showPercentages;
   final bool explodeSlices;
   final double explodeDistance;
+  final LabelCallback labelFormatter;
 
   PieGeometry({
     this.innerRadius = 0.0,
@@ -130,6 +136,8 @@ class PieGeometry extends Geometry {
     this.showPercentages = true,
     this.explodeSlices = false,
     this.explodeDistance = 10.0,
+    LabelCallback? labelFormatter,
     super.interactive = true,
-  }) : super(yAxis: YAxis.primary); // Pie charts don't use Y-axis
+  })  : labelFormatter = labelFormatter ?? _defaultPercentageFormatter.format,
+        super(yAxis: YAxis.primary); // Pie charts don't use Y-axis
 }

--- a/lib/src/core/label_formatter.dart
+++ b/lib/src/core/label_formatter.dart
@@ -1,0 +1,70 @@
+/// Label formatting utility for Cristalyse charts.
+///
+/// This library provides a flexible label formatting system that allows developers
+/// to customize how values are displayed on chart axes and labels. It supports
+/// both simple callbacks and advanced integration with e.g. NumberFormat and
+/// factories with conditional logic.
+///
+/// Example usage:
+/// ```dart
+/// import 'package:intl/intl.dart';
+///
+/// // Simple custom formatting
+/// final formatter = LabelFormatter((value) => '${value}K');
+///
+/// // NumberFormat integration
+/// final currencyFormatter = LabelFormatter(
+///   NumberFormat.currency(symbol: '\$', decimalDigits: 0).format
+/// );
+///
+/// // Default formatting (with older cristalyse behavior)
+/// final defaultFormatter = LabelFormatter();
+/// ```
+library;
+
+/// Type definition for label formatting callbacks.
+///
+/// Defines a function that takes a numeric value and returns a formatted string.
+/// This callback signature is compatible with NumberFormat.format methods.
+///
+/// Example:
+/// ```dart
+/// LabelCallback formatter = (value) => '${value.toStringAsFixed(2)}%';
+/// LabelCallback currencyFormatter = NumberFormat.currency().format;
+/// ```
+typedef LabelCallback = String Function(num value);
+
+/// Handles label formatting with callback support and smart fallbacks.
+///
+/// The [LabelFormatter] class provides a composition-based approach to value
+/// formatting with a smart fallback chain:
+/// 1. Custom callback (if provided)
+/// 2. Default is the original integer/decimal formatting
+/// 3. toString() fallback for non-numeric values
+///
+/// This ensures backwards compatibility while enabling robust customization.
+class LabelFormatter {
+  final LabelCallback? _customCallback;
+
+  const LabelFormatter([this._customCallback]);
+
+  /// Format a value with smart fallback chain:
+  /// custom callback → default formatter → toString()
+  String format(dynamic value) {
+    if (value is num) {
+      if (_customCallback != null) {
+        return _customCallback!(value);
+      }
+      return _formatDefault(value);
+    }
+    return value.toString();
+  }
+
+  static String _formatDefault(num value) {
+    if (value == value.roundToDouble()) {
+      return value.round().toString(); // Integer: 42
+    } else {
+      return value.toStringAsFixed(1); // Decimal: 42.5
+    }
+  }
+}

--- a/lib/src/core/scale.dart
+++ b/lib/src/core/scale.dart
@@ -27,8 +27,7 @@ class LinearScale extends Scale {
   final double? min;
   final double? max;
 
-  LinearScale({this.min, this.max, LabelCallback? labelFormatter})
-      : super(labelFormatter: labelFormatter);
+  LinearScale({this.min, this.max, super.labelFormatter});
 
   @override
   List<double> get domain => _domain;
@@ -72,9 +71,8 @@ class OrdinalScale extends Scale {
   final double _padding; // 10% padding between bands
   double _bandWidth = 0;
 
-  OrdinalScale({double padding = 0.1, LabelCallback? labelFormatter})
-      : _padding = padding,
-        super(labelFormatter: labelFormatter);
+  OrdinalScale({double padding = 0.1, super.labelFormatter})
+      : _padding = padding;
 
   @override
   List<dynamic> get domain => _domain;

--- a/lib/src/core/scale.dart
+++ b/lib/src/core/scale.dart
@@ -1,7 +1,13 @@
 import 'package:flutter/material.dart';
+import 'label_formatter.dart';
 
 /// Base class for all scales
 abstract class Scale {
+  final LabelFormatter _formatter;
+
+  Scale({LabelCallback? labelFormatter})
+      : _formatter = LabelFormatter(labelFormatter);
+
   double scale(dynamic value);
   List<dynamic> getTicks(int count);
   List<dynamic> get domain;
@@ -9,6 +15,9 @@ abstract class Scale {
 
   /// Inverse transformation: convert screen coordinate back to data value
   dynamic invert(double screenValue);
+
+  /// Format a value for display using this Scale instance's label formatter
+  String formatLabel(dynamic value) => _formatter.format(value);
 }
 
 /// Linear scale for continuous data
@@ -18,7 +27,8 @@ class LinearScale extends Scale {
   final double? min;
   final double? max;
 
-  LinearScale({this.min, this.max});
+  LinearScale({this.min, this.max, LabelCallback? labelFormatter})
+      : super(labelFormatter: labelFormatter);
 
   @override
   List<double> get domain => _domain;
@@ -62,7 +72,9 @@ class OrdinalScale extends Scale {
   final double _padding; // 10% padding between bands
   double _bandWidth = 0;
 
-  OrdinalScale({double padding = 0.1}) : _padding = padding;
+  OrdinalScale({double padding = 0.1, LabelCallback? labelFormatter})
+      : _padding = padding,
+        super(labelFormatter: labelFormatter);
 
   @override
   List<dynamic> get domain => _domain;

--- a/lib/src/widgets/animated_chart_widget.dart
+++ b/lib/src/widgets/animated_chart_widget.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 
 import '../core/geometry.dart';
 import '../core/scale.dart';
+import '../core/label_formatter.dart';
 import '../interaction/chart_interactions.dart';
 import '../interaction/interaction_detector.dart';
 import '../interaction/tooltip_widget.dart';
@@ -2272,7 +2273,7 @@ class _AnimatedChartPainter extends CustomPainter {
         paint,
       );
 
-      final label = _formatAxisLabel(tick);
+      final label = xScale.formatLabel(tick);
       final textPainter = TextPainter(
         text: TextSpan(text: label, style: axisLabelStyle),
         textDirection: TextDirection.ltr,
@@ -2303,7 +2304,7 @@ class _AnimatedChartPainter extends CustomPainter {
         paint,
       );
 
-      final label = _formatAxisLabel(tick);
+      final label = yScale.formatLabel(tick);
       final textPainter = TextPainter(
         text: TextSpan(text: label, style: axisLabelStyle),
         textDirection: TextDirection.ltr,
@@ -2330,7 +2331,7 @@ class _AnimatedChartPainter extends CustomPainter {
           paint,
         );
 
-        final label = _formatAxisLabel(tick);
+        final label = y2Scale.formatLabel(tick);
         final textPainter = TextPainter(
           text: TextSpan(
             text: label,
@@ -2501,12 +2502,11 @@ class _AnimatedChartPainter extends CustomPainter {
           canvas,
           sliceCenter,
           currentAngle + animatedSweepAngle / 2,
-          geometry.labelRadius,
           value,
           total,
           category.toString(),
           geometry.labelStyle ?? theme.axisTextStyle,
-          geometry.showPercentages,
+          geometry,
         );
       }
 
@@ -2518,19 +2518,23 @@ class _AnimatedChartPainter extends CustomPainter {
     Canvas canvas,
     Offset center,
     double angle,
-    double radius,
     double value,
     double total,
     String category,
     TextStyle style,
-    bool showPercentages,
+    PieGeometry geometry,
   ) {
+    final radius = geometry.labelRadius;
+    final showPercentages = geometry.showPercentages;
+
     String labelText;
     if (showPercentages) {
-      final percentage = (value / total * 100).toStringAsFixed(1);
-      labelText = '$category\n$percentage%';
+      final percentageRatio = value /
+          total; // 0.0-1.0 range, as NumberFormat expects for percentages
+      final percentageText = geometry.labelFormatter(percentageRatio);
+      labelText = '$category\n$percentageText';
     } else {
-      labelText = '$category\n${_formatAxisLabel(value)}';
+      labelText = '$category\n${geometry.labelFormatter(value)}';
     }
 
     final textPainter = TextPainter(
@@ -2563,18 +2567,6 @@ class _AnimatedChartPainter extends CustomPainter {
     );
 
     textPainter.paint(canvas, labelOffset);
-  }
-
-  String _formatAxisLabel(dynamic value) {
-    if (value is num) {
-      if (value == value.roundToDouble()) {
-        return value.round().toString();
-      } else {
-        return value.toStringAsFixed(1);
-      }
-    } else {
-      return value.toString();
-    }
   }
 
   @override

--- a/lib/src/widgets/animated_chart_widget.dart
+++ b/lib/src/widgets/animated_chart_widget.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 
 import '../core/geometry.dart';
 import '../core/scale.dart';
-import '../core/label_formatter.dart';
 import '../interaction/chart_interactions.dart';
 import '../interaction/interaction_detector.dart';
 import '../interaction/tooltip_widget.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   path_provider: ^2.1.4
   flutter_svg: ^2.0.10+1
   universal_html: ^2.2.4
-  intl: ">=0.17.0"
+  intl: ">=0.17.0 <1.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   path_provider: ^2.1.4
   flutter_svg: ^2.0.10+1
   universal_html: ^2.2.4
+  intl: ">=0.17.0"
 
 dev_dependencies:
   flutter_test:

--- a/test/label_formatting_test.dart
+++ b/test/label_formatting_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:cristalyse/src/core/scale.dart';
+import 'package:cristalyse/src/core/label_formatter.dart';
+
+void main() {
+  group('LabelFormatter Core Functionality', () {
+    test('default formatter preserves existing behavior', () {
+      final scale = LinearScale(); // No custom formatter
+      expect(scale.formatLabel(42), equals('42')); // Integer
+      expect(scale.formatLabel(42.0), equals('42')); // Rounds to integer
+      expect(scale.formatLabel(42.05),
+          equals('42.0')); // Rounds but still displays double
+      expect(scale.formatLabel(42.5), equals('42.5')); // Decimal
+      expect(scale.formatLabel('text'), equals('text')); // String fallback
+    });
+
+    test('custom formatter is called when provided', () {
+      final scale = LinearScale(labelFormatter: (value) => 'custom: $value');
+      expect(scale.formatLabel(42), equals('custom: 42'));
+    });
+  });
+
+  // Test our documentation examples work (not testing NumberFormat itself)
+  group('Documentation Example Verification', () {
+    test('NumberFormat.simpleCurrency example from docs works', () {
+      // Testing the exact example from docs: NumberFormat.simpleCurrency().format
+      final formatter = NumberFormat.simpleCurrency();
+      final scale = LinearScale(labelFormatter: formatter.format);
+
+      // Exact match verification for documentation accuracy
+      expect(scale.formatLabel(1234.56), equals('\$1,234.56'));
+    });
+
+    test('NumberFormat.percentPattern example from docs works', () {
+      // Testing the exact example from docs: NumberFormat.percentPattern().format
+      final formatter = NumberFormat.percentPattern();
+      final scale = LinearScale(labelFormatter: formatter.format);
+
+      // Exact match verification for documentation accuracy
+      expect(scale.formatLabel(0.234), equals('23%'));
+    });
+
+    test('NumberFormat.compact example #1 from docs works', () {
+      // Testing the exact example from docs: NumberFormat.compact().format
+      final formatter = NumberFormat.compact();
+      final scale = LinearScale(labelFormatter: formatter.format);
+
+      // Exact match verification for documentation accuracy
+      expect(scale.formatLabel(1200), equals('1.2K'));
+    });
+
+    test('NumberFormat.compact example #2 from docs works', () {
+      // Testing the exact example from docs: NumberFormat.compact().format
+      final formatter = NumberFormat.compact();
+      final scale = LinearScale(labelFormatter: formatter.format);
+
+      // Exact match verification for documentation accuracy
+      expect(scale.formatLabel(1500000), equals('1.5M'));
+    });
+
+    test('factory pattern example from docs works', () {
+      // Test the createCurrencyFormatter pattern we document - exact match to docs
+      String Function(num) createCurrencyFormatter({String locale = 'en_US'}) {
+        final formatter =
+            NumberFormat.simpleCurrency(locale: locale); // Created once
+        return (num value) => formatter.format(value); // Reused callback
+      }
+
+      final scale = LinearScale(labelFormatter: createCurrencyFormatter());
+      // Exact match verification for documentation accuracy
+      expect(scale.formatLabel(42), equals('\$42.00'));
+    });
+
+    test('createDurationFormatter example from docs works', () {
+      // Test the createDurationFormatter pattern - seconds to human readable
+      String Function(num) createDurationFormatter() {
+        return (num seconds) {
+          final roundedSeconds =
+              seconds.round(); // Round to nearest second first
+
+          if (roundedSeconds >= 3600) {
+            final hours = roundedSeconds / 3600;
+            if (hours == hours.round()) {
+              return '${hours.round()}h'; // Clean: "1h", "2h", "24h"
+            }
+            return '${hours.toStringAsFixed(1)}h'; // Decimal: "1.5h", "2.3h"
+          } else if (roundedSeconds >= 60) {
+            final minutes = (roundedSeconds / 60).round();
+            return '${minutes}m'; // "1m", "30m", "59m"
+          }
+          return '${roundedSeconds}s'; // "5s", "30s", "59s"
+        };
+      }
+
+      final scale = LinearScale(labelFormatter: createDurationFormatter());
+      expect(scale.formatLabel(30), equals('30s')); // Seconds
+      expect(scale.formatLabel(150), equals('3m')); // Minutes
+      expect(scale.formatLabel(3600), equals('1h')); // Clean whole hour
+      expect(scale.formatLabel(7200), equals('2h')); // Clean whole hours
+      expect(scale.formatLabel(5400), equals('1.5h')); // Decimal when needed
+    });
+
+    test('createChartCurrencyFormatter example from docs works', () {
+      // Test the createChartCurrencyFormatter pattern - clean integer currency
+      String Function(num) createChartCurrencyFormatter() {
+        final formatter = NumberFormat.simpleCurrency(locale: 'en_US');
+        return (num value) {
+          if (value == value.roundToDouble()) {
+            return formatter.format(value).replaceAll('.00', ''); // $42
+          }
+          return formatter.format(value); // $42.50
+        };
+      }
+
+      final scale = LinearScale(labelFormatter: createChartCurrencyFormatter());
+      // Exact match verification for documentation accuracy
+      expect(scale.formatLabel(42), equals('\$42')); // Clean integer (no .00)
+      expect(scale.formatLabel(42.50), equals('\$42.50')); // Keep decimals
+    });
+
+    test('createProfitLossFormatter example from docs works', () {
+      // Test the createProfitLossFormatter pattern - profit/loss with +/- signs
+      String Function(num) createProfitLossFormatter() {
+        return (num value) {
+          final abs = value.abs();
+          final formatted = NumberFormat.compact().format(abs);
+          return value >= 0 ? '$formatted' : '($formatted)';
+        };
+      }
+
+      final scale = LinearScale(labelFormatter: createProfitLossFormatter());
+      expect(scale.formatLabel(1500), equals('1.5K')); // Positive
+      expect(scale.formatLabel(-1500), equals('(1.5K)')); // Negative
+      expect(scale.formatLabel(0), equals('0')); // Zero
+    });
+
+    test('createBasisPointFormatter example from docs works', () {
+      // Test the createBasisPointFormatter pattern - finance basis points
+      String Function(num) createBasisPointFormatter() {
+        return (num value) => '${(value * 10000).toStringAsFixed(0)}bp';
+      }
+
+      final scale = LinearScale(labelFormatter: createBasisPointFormatter());
+      expect(scale.formatLabel(0.0025), equals('25bp')); // 0.25% = 25bp
+      expect(scale.formatLabel(0.01), equals('100bp')); // 1% = 100bp
+      expect(scale.formatLabel(0.0001), equals('1bp')); // 0.01% = 1bp
+    });
+  });
+}

--- a/test/label_formatting_test.dart
+++ b/test/label_formatting_test.dart
@@ -121,9 +121,10 @@ void main() {
     test('createProfitLossFormatter example from docs works', () {
       // Test the createProfitLossFormatter pattern - profit/loss with +/- signs
       String Function(num) createProfitLossFormatter() {
+        final formatter = NumberFormat.compact(); // Created once
         return (num value) {
           final abs = value.abs();
-          final formatted = NumberFormat.compact().format(abs);
+          final formatted = formatter.format(abs); // Reuse formatter
           return value >= 0 ? formatted : '($formatted)';
         };
       }

--- a/test/label_formatting_test.dart
+++ b/test/label_formatting_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:cristalyse/src/core/scale.dart';
-import 'package:cristalyse/src/core/label_formatter.dart';
 
 void main() {
   group('LabelFormatter Core Functionality', () {
@@ -125,7 +124,7 @@ void main() {
         return (num value) {
           final abs = value.abs();
           final formatted = NumberFormat.compact().format(abs);
-          return value >= 0 ? '$formatted' : '($formatted)';
+          return value >= 0 ? formatted : '($formatted)';
         };
       }
 

--- a/test/pie_label_formatting_test.dart
+++ b/test/pie_label_formatting_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cristalyse/src/core/chart.dart';
+
+void main() {
+  group('Pie Chart Label Formatting - Integration Tests', () {
+    test('pie chart should work with default label formatter', () {
+      final chart = CristalyseChart()
+          .data([
+            {'category': 'A', 'value': 100},
+            {'category': 'B', 'value': 200},
+          ])
+          .mappingPie(value: 'value', category: 'category')
+          .geomPie(
+            showPercentages: true,
+          );
+
+      expect(chart, isNotNull);
+      final widget = chart.build();
+      expect(widget, isNotNull);
+    });
+
+    test('pie chart should accept custom label formatter', () {
+      final chart = CristalyseChart()
+          .data([
+            {'category': 'A', 'value': 100},
+            {'category': 'B', 'value': 200},
+          ])
+          .mappingPie(value: 'value', category: 'category')
+          .geomPie(
+            labels: (value) => 'Custom: ${value.toStringAsFixed(1)}',
+          );
+
+      expect(chart, isNotNull);
+      final widget = chart.build();
+      expect(widget, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Problem
Charts currently use basic number formatting (42, 42.5) which isn't suitable for business dashboards showing currency, percentages, or large numbers.

## Solution
Add optional `labels` callback parameter to scale methods enabling custom formatting:

```dart
// Simple callbacks
.scaleYContinuous(labels: (value) => '\$${value}K')

// NumberFormat integration
.scaleYContinuous(labels: NumberFormat.simpleCurrency().format)
.scaleY2Continuous(labels: NumberFormat.percentPattern().format)
```

## Implementation

- LabelCallback typedef and LabelFormatter class for type safety
- Zero breaking changes - all existing charts work unchanged
- Smart defaults preserve current behavior when no formatter provided

## Documentation and Examples
- Docs updated in general
- Documented factory patterns for performance-critical NumberFormat usage
- Updated example pie charts, bar charts, and dual-axis charts to demonstrate formatting with currency, percentages, and compact notation.