### PR TITLE
add test for epoch ms labeling

### DIFF
--- a/lib/src/core/util/wilkinson_labeling.dart
+++ b/lib/src/core/util/wilkinson_labeling.dart
@@ -237,7 +237,7 @@ class WilkinsonLabeling {
   /// Clean up floating point artifacts
   static double _cleanNumber(double value) {
     // Round to 10 decimal places to eliminate floating point errors
-    final rounded = (value * 1e10).round() / 1e10;
+    final rounded = (value * 1e10).roundToDouble() / 1e10;
 
     // If very close to an integer, return the integer
     if ((rounded - rounded.round()).abs() < 1e-10) {

--- a/test/wilkinson_labeling_test.dart
+++ b/test/wilkinson_labeling_test.dart
@@ -236,5 +236,17 @@ void main() {
       expect(ticks.first, greaterThanOrEqualTo(50.0));
       expect(ticks.last, lessThanOrEqualTo(51.0));
     });
+
+    test('Bigger numbers, replicate epoch ms', () {
+      final ticks = WilkinsonLabeling.extended(
+          1760530211058.0, 1760526611058.0, 852.4, 0.0164,
+          limits: (1760526611058.0, 1760530211058.0));
+
+      // All ticks must be within limits
+      expect(ticks.isNotEmpty, true);
+      expect(ticks.length, 4);
+      expect(ticks,
+          [1760527000000.0, 1760528000000.0, 1760529000000.0, 1760530000000.0]);
+    });
   });
 }


### PR DESCRIPTION
before the output of ticks was, 

Actual: [922337203.6854776, 922337203.6854776, 922337203.6854776, 922337203.6854776]

it was an integer overflow

