### PR TITLE
fix updatable y axis bounds while panning x axis,

### DIFF
--- a/lib/src/core/util/painter.dart
+++ b/lib/src/core/util/painter.dart
@@ -46,6 +46,11 @@ AnimatedChartPainter chartPainterAnimated(
     required double animationProgress,
     List<double>? panXDomain,
     List<double>? panYDomain}) {
+  // Force panYDomain to null if updateYDomain is false
+  // otherwise the configured Y domain will be overridden by the original domain during set bounds
+  if (widget.interaction.pan?.updateYDomain == false) {
+    panYDomain = null;
+  }
   return AnimatedChartPainter(
     data: widget.data,
     xColumn: widget.xColumn,


### PR DESCRIPTION
the y axis got stuck with the original bounds set by panYDomain


<img width="645" height="270" alt="image" src="https://github.com/user-attachments/assets/1aa174b7-fa09-4ff8-9e51-4076705dc6f6" />
