### PR TITLE
fix: render single-segment pie/donut charts correctly

### DIFF
--- a/lib/src/widgets/animated_chart_painter.dart
+++ b/lib/src/widgets/animated_chart_painter.dart
@@ -2102,7 +2102,7 @@ class AnimatedChartPainter extends CustomPainter {
     // Use pie-specific columns or fall back to regular columns
     final valueColumn = pieValueColumn ?? yColumn;
     final categoryColumn = pieCategoryColumn ?? colorColumn ?? xColumn;
-
+    
     if (valueColumn == null || categoryColumn == null || data.isEmpty) {
       return;
     }
@@ -2136,7 +2136,7 @@ class AnimatedChartPainter extends CustomPainter {
     double currentAngle = geometry.startAngle;
     // Cap sweep angle just below 2π to avoid Flutter's arcTo() issue
     // where a full circle (2π radians) fails to render
-    const maxSweepAngle = (2 * math.pi) - 0.0001;
+    static const double _maxPieArcSweepAngle = (2 * math.pi) - 0.0001;
     for (int i = 0; i < data.length; i++) {
       final value = values[i];
       if (value <= 0) continue;

--- a/lib/src/widgets/animated_chart_painter.dart
+++ b/lib/src/widgets/animated_chart_painter.dart
@@ -2134,7 +2134,9 @@ class AnimatedChartPainter extends CustomPainter {
 
     // Draw pie slices
     double currentAngle = geometry.startAngle;
-
+    // Cap sweep angle just below 2π to avoid Flutter's arcTo() issue
+    // where a full circle (2π radians) fails to render
+    const maxSweepAngle = (2 * math.pi) - 0.0001;
     for (int i = 0; i < data.length; i++) {
       final value = values[i];
       if (value <= 0) continue;
@@ -2159,9 +2161,7 @@ class AnimatedChartPainter extends CustomPainter {
         continue;
       }
 
-      // Cap sweep angle just below 2π to avoid Flutter's arcTo() issue
-      // where a full circle (2π radians) fails to render
-      const maxSweepAngle = (2 * math.pi) - 0.0001;
+     
       final animatedSweepAngle =
           math.min(sweepAngle * sliceProgress, maxSweepAngle);
 

--- a/lib/src/widgets/animated_chart_painter.dart
+++ b/lib/src/widgets/animated_chart_painter.dart
@@ -2159,7 +2159,11 @@ class AnimatedChartPainter extends CustomPainter {
         continue;
       }
 
-      final animatedSweepAngle = sweepAngle * sliceProgress;
+      // Cap sweep angle just below 2π to avoid Flutter's arcTo() issue
+      // where a full circle (2π radians) fails to render
+      const maxSweepAngle = (2 * math.pi) - 0.0001;
+      final animatedSweepAngle =
+          math.min(sweepAngle * sliceProgress, maxSweepAngle);
 
       // Calculate slice center for explosion effect
       Offset sliceCenter = center;

--- a/test/animated_chart_test.dart
+++ b/test/animated_chart_test.dart
@@ -127,4 +127,66 @@ void main() {
     // Allow animations to complete
     await tester.pumpAndSettle();
   });
+
+  testWidgets(
+      'AnimatedCristalyseChartWidget handles single-segment pie chart correctly',
+      (WidgetTester tester) async {
+    // Single segment data - tests the 2π sweep angle edge case
+    final singleSegmentData = [
+      {'category': 'Total', 'value': 100},
+    ];
+
+    final widget = MaterialApp(
+      home: Scaffold(
+        body: AnimatedCristalyseChartWidget(
+          data: singleSegmentData,
+          pieCategoryColumn: 'category',
+          pieValueColumn: 'value',
+          geometries: [PieGeometry(showLabels: true, showPercentages: true)],
+          theme: ChartTheme.defaultTheme(),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(widget);
+    await tester.pump();
+
+    expect(find.byType(AnimatedCristalyseChartWidget), findsOneWidget);
+
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+      'AnimatedCristalyseChartWidget handles single-segment donut chart correctly',
+      (WidgetTester tester) async {
+    // Single segment donut - tests the 2π sweep angle edge case with inner radius
+    final singleSegmentData = [
+      {'category': 'Total', 'value': 100},
+    ];
+
+    final widget = MaterialApp(
+      home: Scaffold(
+        body: AnimatedCristalyseChartWidget(
+          data: singleSegmentData,
+          pieCategoryColumn: 'category',
+          pieValueColumn: 'value',
+          geometries: [
+            PieGeometry(
+              showLabels: true,
+              showPercentages: true,
+              innerRadius: 50.0, // Makes it a donut chart
+            ),
+          ],
+          theme: ChartTheme.defaultTheme(),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(widget);
+    await tester.pump();
+
+    expect(find.byType(AnimatedCristalyseChartWidget), findsOneWidget);
+
+    await tester.pumpAndSettle();
+  });
 }


### PR DESCRIPTION
Flutter's Path.arcTo() fails silently when sweep angle equals 2π radians (full circle). This caused single-segment pie and donut charts to not render at all.

Cap the sweep angle to just below 2π (2π - 0.0001) to avoid this edge case while maintaining an imperceptible visual difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)