### PR TITLE
fix: keep single-slice pie/donut charts visible after the enter animation

### DIFF
--- a/lib/src/widgets/animated_chart_painter.dart
+++ b/lib/src/widgets/animated_chart_painter.dart
@@ -2200,7 +2200,27 @@ class AnimatedChartPainter extends CustomPainter {
 
       // Create slice path
       final path = Path();
-      if (innerRadius > 0) {
+      // Flutter's [Path.arcTo] draws nothing for a full 2*pi sweep, so a lone
+      // slice (one category at 100%) collapses to an empty path on the final
+      // animation frame and disappears. Build the shape from ovals instead
+      // once the sweep completes a full circle.
+      const fullCircle = 2 * math.pi;
+      if (animatedSweepAngle >= fullCircle) {
+        if (innerRadius > 0) {
+          // Full donut ring: outer circle with the inner circle punched out.
+          path.fillType = PathFillType.evenOdd;
+          path
+            ..addOval(Rect.fromCircle(center: sliceCenter, radius: outerRadius))
+            ..addOval(
+              Rect.fromCircle(center: sliceCenter, radius: innerRadius),
+            );
+        } else {
+          // Full pie: a complete circle.
+          path.addOval(
+            Rect.fromCircle(center: sliceCenter, radius: outerRadius),
+          );
+        }
+      } else if (innerRadius > 0) {
         // Donut chart - create proper donut slice path
         final outerStartX =
             sliceCenter.dx + math.cos(currentAngle) * outerRadius;

--- a/test/single_slice_pie_test.dart
+++ b/test/single_slice_pie_test.dart
@@ -1,0 +1,96 @@
+import 'dart:ui' as ui;
+
+import 'package:cristalyse/src/core/geometry.dart';
+import 'package:cristalyse/src/themes/chart_theme.dart';
+import 'package:cristalyse/src/widgets/animated_chart_painter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression coverage for the single-slice pie/donut bug: a chart with one
+/// category at 100% sweeps a full `2 * pi` at the final animation frame, and
+/// `Path.arcTo` renders nothing for a full-circle sweep, so the slice used to
+/// collapse to an empty path and disappear the instant the enter animation
+/// completed.
+///
+/// The painter fills a solid background, so an opaque-pixel count can't tell a
+/// drawn slice from an empty one. Instead we count pixels that differ from a
+/// reference background pixel (one taken well outside the pie radius): a broken
+/// build draws no slice, so almost every pixel matches the background; a correct
+/// build fills the disc (pie) or ring (donut) with the slice colour, producing
+/// tens of thousands of non-background pixels.
+Future<int> _nonBackgroundPixelCount(CustomPainter painter, Size size) async {
+  final width = size.width.toInt();
+  final height = size.height.toInt();
+
+  final recorder = ui.PictureRecorder();
+  painter.paint(Canvas(recorder), size);
+  final picture = recorder.endRecording();
+  final image = await picture.toImage(width, height);
+  final bytes = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  image.dispose();
+  picture.dispose();
+
+  final data = bytes!.buffer.asUint8List();
+
+  // Reference background pixel: vertically centred, near the right edge — well
+  // outside the pie/donut radius for a 400x400 canvas.
+  final refIndex = (height ~/ 2 * width + (width - 20)) * 4;
+  final r = data[refIndex], g = data[refIndex + 1];
+  final b = data[refIndex + 2], a = data[refIndex + 3];
+
+  var nonBackground = 0;
+  for (var i = 0; i < data.length; i += 4) {
+    if (data[i + 3] == 0) continue; // ignore fully transparent pixels
+    if (data[i] == r && data[i + 1] == g && data[i + 2] == b && data[i + 3] == a) {
+      continue; // ignore background-coloured pixels
+    }
+    nonBackground++;
+  }
+  return nonBackground;
+}
+
+void main() {
+  const size = Size(400, 400);
+  final singleSlice = <Map<String, dynamic>>[
+    {'category': 'A', 'value': 100},
+  ];
+
+  AnimatedChartPainter buildPainter(double innerRadius) => AnimatedChartPainter(
+        data: singleSlice,
+        pieCategoryColumn: 'category',
+        pieValueColumn: 'value',
+        geometries: [PieGeometry(innerRadius: innerRadius)],
+        theme: ChartTheme.defaultTheme(),
+        animationProgress: 1.0,
+      );
+
+  testWidgets(
+    'single-slice pie stays visible when the enter animation completes',
+    (tester) async {
+      await tester.runAsync(() async {
+        final drawn = await _nonBackgroundPixelCount(buildPainter(0.0), size);
+        expect(
+          drawn,
+          greaterThan(3000),
+          reason: 'a single 100% pie slice must fill the disc at full animation '
+              'progress, not collapse to an empty path',
+        );
+      });
+    },
+  );
+
+  testWidgets(
+    'single-slice donut stays visible when the enter animation completes',
+    (tester) async {
+      await tester.runAsync(() async {
+        final drawn = await _nonBackgroundPixelCount(buildPainter(60.0), size);
+        expect(
+          drawn,
+          greaterThan(3000),
+          reason: 'a single 100% donut slice must fill the ring at full animation '
+              'progress, not collapse to an empty path',
+        );
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #97. A pie or donut chart with a single slice (one category making up
100% of the total) animates in correctly but disappears the moment the enter
animation finishes. It is only visible while the animation is still running.

## Root cause

`AnimatedChartPainter._drawPieAnimated` in
`lib/src/widgets/animated_chart_painter.dart` builds each slice with
`Path.arcTo` (outer/inner arcs for a donut at lines ~2238 and ~2249, the pie
wedge at line ~2261). The animated sweep angle is:

```dart
final sweepAngle = (value / total) * 2 * math.pi;   // line 2169
final animatedSweepAngle = sweepAngle * sliceProgress; // line 2189
```

For a lone slice, `value / total == 1.0`, so `sweepAngle == 2*pi`. At the final
frame `sliceProgress == 1.0`, making `animatedSweepAngle` exactly `2*pi`.

`Path.arcTo` draws nothing for a full `2*pi` sweep: its start and stop unit
vectors coincide, so the arc collapses to a zero-length segment and the slice
path ends up empty. This is unlike `Canvas.drawArc` (used elsewhere in this file
for the radial gauges), which special-cases a full-circle sweep to a complete
oval. Mid-animation the sweep is still below `2*pi`, which is exactly why the
slice renders during the animation and only vanishes when it completes. The same
happens for a full pie (`innerRadius: 0`), not just donuts.

## Change

In `_drawPieAnimated`, when `animatedSweepAngle` reaches a full circle, build the
shape from ovals instead of `arcTo`:

- Full pie: a single filled circle (`addOval`).
- Full donut: an even-odd outer/inner oval pair, giving a proper ring.

Partial slices (`sweep < 2*pi`) keep the existing `arcTo` path untouched, so
multi-slice pies and donuts render exactly as before. The change is contained to
the slice-path construction; the existing fill, stroke, label, and explode logic
apply to the new path unchanged (fill yields the disc/ring; stroke yields the
circle outline(s), which is the correct outline for a complete pie/ring).

## Validation

- Deterministic root-cause trace against the current source (v1.17.6): the only
  code path that can produce a `2*pi` `arcTo` sweep is a slice whose
  `value / total == 1.0` at `sliceProgress == 1.0`; for every partial slice
  `animatedSweepAngle < 2*pi`, so the branch and its output are unchanged.
- Non-regression reasoning: multi-slice pies never reach the new branch because
  each slice's sweep is strictly less than `2*pi`.
- **Automated regression test** (`test/single_slice_pie_test.dart`): renders
  `AnimatedChartPainter` at `animationProgress: 1.0` for a one-category (100%)
  dataset and counts the pixels that differ from the background, asserting the
  slice actually fills the disc (pie) and the ring (donut). The failure mode is
  a *visually empty fill* — the painter still paints, just a zero-area path — so
  the existing `findsOneWidget`-style tests can't detect it; a pixel check can.
  Confirmed the test **fails on the pre-fix `arcTo` path** (~800 non-background
  pixels — the empty full-circle sweep) and **passes with this change** (~21k–32k
  non-background pixels for the ring / disc), covering the exact regression the
  existing multi-slice pie test misses.
- **Full suite green:** `flutter test` — 299/299 passing, including the two new
  cases; no other test affected.

## Reproduction

```dart
CristalyseChart()
  .data([{'label': 'a', 'value': 1}])
  .mappingPie(value: 'value', category: 'label')
  .geomPie(innerRadius: 26)
  .build();
```

The donut renders during the animation, then vanishes when it completes on
`main`; with this change it stays as a full ring. Setting `innerRadius: 0`
reproduces the same behavior for a full pie.
